### PR TITLE
Anonymous auth & Spotify mix playlists

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,15 @@
     "@types/node": "^22.13.14",
     "@typescript-eslint/eslint-plugin": "^8.26.1",
     "@typescript-eslint/parser": "^8.26.1",
-    "cheerio": "^1.0.0",
     "discord-player": "^7.1.0",
     "discord.js": "^14.18.0",
     "eslint": "^9.22.0",
     "globals": "^16.0.0",
-    "otpauth": "^9.3.6",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2"
+  },
+  "dependencies": {
+    "node-html-parser": "^7.0.1",
+    "otpauth": "^9.3.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist",
     "code": "git pull && npm i && code . && eslint src",
-    "c": "npm run code"
+    "c": "npm run code",
+    "prepare": "npm run build"
   },
   "author": "iTsMaaT",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,49 +1,51 @@
 {
-    "name": "discord-player-spotify",
-    "version": "1.0.1",
-    "description": "A spotify extractor for discord-player",
-    "main": "dist/index.cjs",
-    "module": "dist/index.mjs",
-    "exports": {
-        ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js",
-            "require": "./dist/index.cjs"
-        }
-    },
-    "type": "module",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
-        "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist",
-        "code": "git pull && npm i && code . && eslint src",
-        "c": "npm run code"
-    },
-    "author": "iTsMaaT",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/iTsMaaT/discord-player-spotify.git"
-    },
-    "bugs": {
-        "url": "https://github.com/iTsMaaT/discord-player-spotify"
-    },
-    "homepage": "https://github.com/iTsMaaT/discord-player-spotify",
-    "keywords": [
-        "discord",
-        "bot",
-        "music",
-        "soundcloud",
-        "discord-player"
-    ],
-    "devDependencies": {
-        "@types/node": "^22.13.10",
-        "@typescript-eslint/eslint-plugin": "^8.26.1",
-        "@typescript-eslint/parser": "^8.26.1",
-        "discord-player": "^7.1.0",
-        "discord.js": "^14.18.0",
-        "eslint": "^9.22.0",
-        "globals": "^16.0.0",
-        "tsup": "^8.4.0",
-        "typescript": "^5.8.2"
+  "name": "discord-player-spotify",
+  "version": "1.0.1",
+  "description": "A spotify extractor for discord-player",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
+  },
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist",
+    "code": "git pull && npm i && code . && eslint src",
+    "c": "npm run code"
+  },
+  "author": "iTsMaaT",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iTsMaaT/discord-player-spotify.git"
+  },
+  "bugs": {
+    "url": "https://github.com/iTsMaaT/discord-player-spotify"
+  },
+  "homepage": "https://github.com/iTsMaaT/discord-player-spotify",
+  "keywords": [
+    "discord",
+    "bot",
+    "music",
+    "soundcloud",
+    "discord-player"
+  ],
+  "devDependencies": {
+    "@types/node": "^22.13.14",
+    "@typescript-eslint/eslint-plugin": "^8.26.1",
+    "@typescript-eslint/parser": "^8.26.1",
+    "cheerio": "^1.0.0",
+    "discord-player": "^7.1.0",
+    "discord.js": "^14.18.0",
+    "eslint": "^9.22.0",
+    "globals": "^16.0.0",
+    "otpauth": "^9.3.6",
+    "tsup": "^8.4.0",
+    "typescript": "^5.8.2"
+  }
 }

--- a/src/SpotifyExtractor.ts
+++ b/src/SpotifyExtractor.ts
@@ -1,205 +1,173 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {
-    BaseExtractor,
-    ExtractorInfo,
-    ExtractorSearchContext,
-    ExtractorStreamable,
-    Playlist,
-    Track,
-    Util,
-} from "discord-player";
+import { BaseExtractor, ExtractorInfo, ExtractorSearchContext, ExtractorStreamable, Playlist, Track, Util } from "discord-player";
 import type { Readable } from "stream";
 import { SpotifyAPI } from "./internal/spotify";
-import { 
-    spotifySongRegex, 
-    spotifyPlaylistRegex, 
-    spotifyAlbumRegex,
-    isUrl,
-    parseSpotifyUrl,
-    market,
-} from "./internal/helper";
+import { spotifySongRegex, spotifyPlaylistRegex, spotifyAlbumRegex, isUrl, parseSpotifyUrl, market } from "./internal/helper";
 
-type StreamFN = (
-    url: string,
-    track: Track,
-) => Promise<Readable | string>;
+type StreamFN = (url: string, track: Track) => Promise<Readable | string>;
 
 export interface SpotifyExtractorInit {
-    clientId: string;
-    clientSecret: string;
-    market?: string | null;
-    createStream?: (
-      ext: SpotifyExtractor,
-      url: string,
-    ) => Promise<Readable | string>;
+  clientId?: string;
+  clientSecret?: string;
+  market?: string | null;
+  createStream?: (ext: SpotifyExtractor, url: string) => Promise<Readable | string>;
 }
 
 export { parseSpotifyUrl };
 
 export class SpotifyExtractor extends BaseExtractor<SpotifyExtractorInit> {
-    public static identifier = "com.discord-player.spotifyextractor" as const;
-    private _stream!: StreamFN;
-    private _credentials = {
-        clientId: this.options.clientId || process.env.DP_SPOTIFY_CLIENT_ID || "",
-        clientSecret:
-        this.options.clientSecret || process.env.DP_SPOTIFY_CLIENT_SECRET || "",
-    };
+  public static identifier = "com.discord-player.spotifyextractor" as const;
+  private _stream!: StreamFN;
+  private _credentials = {
+    clientId: this.options.clientId || process.env.DP_SPOTIFY_CLIENT_ID || "",
+    clientSecret: this.options.clientSecret || process.env.DP_SPOTIFY_CLIENT_SECRET || "",
+  };
 
-    private _market = this.options.market || market;
+  private _market = this.options.market || market;
 
-    public internal = new SpotifyAPI({ ...this._credentials, market: this._market });
-  
-    public async activate(): Promise<void> {
-        this.protocols = ["spsearch", "spotify"];
-  
-        const fn = this.options.createStream;
-        if (typeof fn === "function") {
-            this._stream = (q: string) => {
-                return fn(this, q);
-            };
-        }
+  public internal = new SpotifyAPI({ ...this._credentials, market: this._market });
+
+  public async activate(): Promise<void> {
+    this.protocols = ["spsearch", "spotify"];
+
+    const fn = this.options.createStream;
+    if (typeof fn === "function") {
+      this._stream = (q: string) => {
+        return fn(this, q);
+      };
     }
-  
-    public async deactivate() {
-        this._stream = undefined as unknown as StreamFN;
-        this.protocols = [];
-    }
-  
-    public async validate(query: string): Promise<boolean> {
-        return !isUrl(query) ||
-      [spotifyAlbumRegex, spotifyPlaylistRegex, spotifySongRegex ].some(regex => regex.test(query));
+  }
+
+  public async deactivate() {
+    this._stream = undefined as unknown as StreamFN;
+    this.protocols = [];
+  }
+
+  public async validate(query: string): Promise<boolean> {
+    return !isUrl(query) || [spotifyAlbumRegex, spotifyPlaylistRegex, spotifySongRegex].some((regex) => regex.test(query));
+  }
+
+  buildTrack(trackInfo: any, context: ExtractorSearchContext, playlist?: Playlist): Track {
+    return new Track(this.context.player, {
+      title: trackInfo.name || trackInfo.title,
+      description: `${trackInfo.name || trackInfo.title} by ${
+        Array.isArray(trackInfo.artists) ? trackInfo.artists.map((m: any) => m.name).join(", ") : trackInfo.artist || "Unknown Artist"
+      }`,
+      author: Array.isArray(trackInfo.artists) ? trackInfo.artists[0]?.name : trackInfo.artist || "Unknown Artist",
+      url: trackInfo.external_urls?.spotify || trackInfo.url || `https://open.spotify.com/track/${trackInfo.id}`,
+      thumbnail: trackInfo.album?.images?.[0]?.url || trackInfo.thumbnail || "https://www.scdn.co/i/_global/twitter_card-default.jpg",
+      duration: Util.buildTimeCode(Util.parseMS(trackInfo.duration_ms || trackInfo.duration || 0)),
+      views: 0,
+      requestedBy: context.requestedBy,
+      source: "spotify",
+      metadata: {
+        source: trackInfo,
+        bridge: null,
+      },
+      requestMetadata: async () => ({
+        source: trackInfo,
+        bridge: null,
+      }),
+      playlist: playlist,
+    });
+  }
+
+  buildPlaylist(data: any, context: ExtractorSearchContext, type: "album" | "playlist" = "playlist"): Playlist {
+    const playlist = new Playlist(this.context.player, {
+      title: data.name,
+      description: "",
+      thumbnail: data.thumbnail,
+      type,
+      source: "spotify",
+      author: {
+        name: data.author,
+        url: null as unknown as string,
+      },
+      tracks: [],
+      id: data.id,
+      url: data.url,
+      rawPlaylist: data,
+    });
+
+    playlist.tracks = (data.tracks || []).map((trackData: any) => {
+      const track = new Track(this.context.player, {
+        title: trackData.name,
+        description: `${trackData.name} by ${trackData.artists.map((a: any) => a.name).join(", ")}`,
+        author: trackData.artists[0].name,
+        url: trackData.external_urls.spotify,
+        thumbnail: trackData.album?.images?.[0]?.url || "https://www.scdn.co/i/_global/twitter_card-default.jpg",
+        duration: Util.buildTimeCode(Util.parseMS(trackData.duration_ms)),
+        views: 0,
+        requestedBy: context.requestedBy,
+        source: "spotify",
+        metadata: {
+          source: trackData,
+          bridge: null,
+        },
+        requestMetadata: async () => ({
+          source: trackData,
+          bridge: null,
+        }),
+        playlist: playlist,
+      });
+      track.extractor = this;
+      return track;
+    });
+
+    return playlist;
+  }
+
+  public async handle(query: string, context: ExtractorSearchContext): Promise<ExtractorInfo> {
+    const { id } = parseSpotifyUrl(query);
+    if (spotifySongRegex.test(query)) {
+      const spotifyData = await this.internal.getTrack(id);
+      if (!spotifyData) return this.createResponse();
+
+      const track = this.buildTrack(spotifyData, context);
+      track.extractor = this;
+
+      return this.createResponse(null, [track]);
     }
 
-     
-    buildTrack(trackInfo: any, context: ExtractorSearchContext, playlist?: Playlist): Track {
-        return new Track(this.context.player, {
-            title: trackInfo.name || trackInfo.title,
-            description: `${trackInfo.name || trackInfo.title} by ${Array.isArray(trackInfo.artists) 
-                 
-                ? trackInfo.artists.map((m: any) => m.name).join(", ") 
-                : trackInfo.artist || "Unknown Artist"}`,
-            author: Array.isArray(trackInfo.artists) 
-                ? trackInfo.artists[0]?.name 
-                : trackInfo.artist || "Unknown Artist",
-            url: trackInfo.external_urls?.spotify || trackInfo.url || `https://open.spotify.com/track/${trackInfo.id}`,
-            thumbnail: trackInfo.album?.images?.[0]?.url || trackInfo.thumbnail || "https://www.scdn.co/i/_global/twitter_card-default.jpg",
-            duration: Util.buildTimeCode(Util.parseMS(trackInfo.duration_ms || trackInfo.duration || 0)),
-            views: 0,
-            requestedBy: context.requestedBy,
-            source: "spotify",
-            metadata: {
-                source: trackInfo,
-                bridge: null,
-            },
-            requestMetadata: async () => ({
-                source: trackInfo,
-                bridge: null,
-            }),
-            playlist: playlist,
-        });
+    if (spotifyPlaylistRegex.test(query)) {
+      const spotifyPlaylist = await this.internal.getPlaylist(id);
+      if (!spotifyPlaylist) return this.createResponse();
+
+      const playlist = this.buildPlaylist(spotifyPlaylist, context, "playlist");
+      return this.createResponse(playlist, playlist.tracks);
     }
 
-     
-    buildPlaylist(data: any, context: ExtractorSearchContext, type: "album" | "playlist" = "playlist"): Playlist {
-        const playlist = new Playlist(this.context.player, {
-            title: data.name,
-            description: "",
-            thumbnail: data.thumbnail,
-            type,
-            source: "spotify",
-            author: {
-                name: data.author,
-                url: null as unknown as string,
-            },
-            tracks: [],
-            id: data.id,
-            url: data.url,
-            rawPlaylist: data,
-        });
-    
-        playlist.tracks = (data.tracks || []).map((trackData: any) => {
-            const track = new Track(this.context.player, {
-                title: trackData.name,
-                description: `${trackData.name} by ${trackData.artists.map((a: any) => a.name).join(", ")}`,
-                author: trackData.artists[0].name,
-                url: trackData.external_urls.spotify,
-                thumbnail: trackData.album?.images?.[0]?.url || "https://www.scdn.co/i/_global/twitter_card-default.jpg",
-                duration: Util.buildTimeCode(Util.parseMS(trackData.duration_ms)),
-                views: 0,
-                requestedBy: context.requestedBy,
-                source: "spotify",
-                metadata: {
-                    source: trackData,
-                    bridge: null,
-                },
-                requestMetadata: async () => ({
-                    source: trackData,
-                    bridge: null,
-                }),
-                playlist: playlist,
-            });
-            track.extractor = this;
-            return track;
-        });
-    
-        return playlist;
+    if (spotifyAlbumRegex.test(query)) {
+      const spotifyAlbum = await this.internal.getAlbum(id);
+      if (!spotifyAlbum) return this.createResponse();
+
+      const playlist = this.buildPlaylist(spotifyAlbum, context, "album");
+      return this.createResponse(playlist, playlist.tracks);
     }
-  
-    public async handle(
-        query: string,
-        context: ExtractorSearchContext,
-    ): Promise<ExtractorInfo> {
-        const { id } = parseSpotifyUrl(query);
-        if (spotifySongRegex.test(query)) {
-            const spotifyData = await this.internal.getTrack(id);
-            if (!spotifyData) return this.createResponse();
-    
-            const track = this.buildTrack(spotifyData, context);
-            track.extractor = this;
-    
-            return this.createResponse(null, [track]);
-        }
-    
-        if (spotifyPlaylistRegex.test(query)) {
-            const spotifyPlaylist = await this.internal.getPlaylist(id);
-            if (!spotifyPlaylist) return this.createResponse();
 
-            const playlist = this.buildPlaylist(spotifyPlaylist, context, "playlist");
-            return this.createResponse(playlist, playlist.tracks); 
-        }
-    
-        if (spotifyAlbumRegex.test(query)) {
-            const spotifyAlbum = await this.internal.getAlbum(id);
-            if (!spotifyAlbum) return this.createResponse();
+    const data = await this.internal.search(query);
+    if (!data) return this.createResponse();
 
-            const playlist = this.buildPlaylist(spotifyAlbum, context, "album");
-            return this.createResponse(playlist, playlist.tracks);
-        }
+    return this.createResponse(
+      null,
+      data.map((spotifyData) => {
+        const track = this.buildTrack(spotifyData, context);
+        track.extractor = this;
+        return track;
+      })
+    );
+  }
 
-        const data = await this.internal.search(query);
-        if (!data) return this.createResponse();
-    
-        return this.createResponse(
-            null,
-            data.map((spotifyData) => {
-                const track = this.buildTrack(spotifyData, context);
-                track.extractor = this;
-                return track;
-            }),
-        );
-    
+  public async stream(info: Track): Promise<ExtractorStreamable> {
+    if (this._stream) {
+      const stream = await this._stream(info.url, info);
+      return stream;
     }
-  
-    public async stream(info: Track): Promise<ExtractorStreamable> {
-        if (this._stream) {
-            const stream = await this._stream(info.url, info);
-            return stream;
-        }
-  
-        const result = await this.context.requestBridge(info, this);
 
-        if (!result?.result) throw new Error("Could not bridge this track");
-  
-        return result.result;
-    }
+    const result = await this.context.requestBridge(info, this);
+
+    if (!result?.result) throw new Error("Could not bridge this track");
+
+    return result.result;
+  }
 }

--- a/src/internal/helper.ts
+++ b/src/internal/helper.ts
@@ -1,7 +1,7 @@
 export const UA =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 Edg/109.0.1518.49";
 
-export const market = "US";
+export const market = "";
 
 export const spotifyUrlRegex = 
   /^(?:https:\/\/open\.spotify\.com\/(intl-([a-z]|[A-Z]){0,3}\/)?(?:user\/[A-Za-z0-9]+\/)?|spotify:)(album|playlist|track)(?:[/:])([A-Za-z0-9]+).*$/;

--- a/src/internal/spotify.ts
+++ b/src/internal/spotify.ts
@@ -1,6 +1,7 @@
 import { TOTP } from "otpauth";
 import { UA, market } from "./helper";
 import * as cheerio from "cheerio";
+import { Buffer } from "node:buffer";
 
 const SP_BASE = "https://api.spotify.com/v1";
 

--- a/src/internal/spotify.ts
+++ b/src/internal/spotify.ts
@@ -53,15 +53,12 @@ export class SpotifyAPI {
             body: "grant_type=client_credentials",
           };
 
-      const token1 = await fetch(accessTokenUrl, fetchOptions);
-
-      const token = await token1.json();
-
-      if (!token) throw new Error("Failed to retrieve access token.");
+      const tokenData = await fetch(accessTokenUrl, fetchOptions).then((v) => v.json());
+      if (!tokenData) throw new Error("Failed to retrieve access token.");
 
       this.accessToken = {
-        token: token.accessToken,
-        expiresAfter: Date.now() + token.accessTokenExpirationTimestampMs,
+        token: !this.useCredentials ? tokenData.accessToken : tokenData.access_token,
+        expiresAfter: !this.useCredentials ? Date.now() + tokenData.accessTokenExpirationTimestampMs : Date.now() + tokenData.expires_in * 1000,
         type: "Bearer",
       };
     } catch (error) {

--- a/src/internal/spotify.ts
+++ b/src/internal/spotify.ts
@@ -1,7 +1,7 @@
+import { TOTP } from "otpauth";
 import { UA, market } from "./helper";
+import * as cheerio from "cheerio";
 
-const SP_ACCESS_TOKEN_URL =
-  "https://accounts.spotify.com/api/token?grant_type=client_credentials";
 const SP_BASE = "https://api.spotify.com/v1";
 
 interface SP_ACCESS_TOKEN {
@@ -11,114 +11,114 @@ interface SP_ACCESS_TOKEN {
 }
 
 export class SpotifyAPI {
-    public accessToken: SP_ACCESS_TOKEN | null = null;
-    private clientId: string;
-    private clientSecret: string;
-    private market: string;
+  public accessToken: SP_ACCESS_TOKEN | null = null;
+  private clientId: string | undefined;
+  private clientSecret: string | undefined;
+  private market: string;
+  private useCredentials: boolean = false;
 
-    constructor(credentials: { clientId: string; clientSecret: string, market?: string }) {
-        if (!credentials.clientId || !credentials.clientSecret) 
-            throw new Error("Spotify clientId and clientSecret are required.");
-    
-        this.clientId = credentials.clientId;
-        this.clientSecret = credentials.clientSecret;
-        this.market = credentials.market || market;
+  constructor(credentials: { clientId?: string; clientSecret?: string; market?: string }) {
+    if (credentials.clientId && credentials.clientSecret) {
+      this.useCredentials = true;
+
+      this.clientId = credentials.clientId;
+      this.clientSecret = credentials.clientSecret;
     }
+    this.market = credentials.market || market;
+  }
 
-    private get authorizationKey() {
-        return Buffer.from(`${this.clientId}:${this.clientSecret}`).toString("base64");
+  private get authorizationKey() {
+    return Buffer.from(`${this.clientId}:${this.clientSecret}`).toString("base64");
+  }
+
+  public async requestToken() {
+    try {
+      const accessTokenUrl = await this.getAccessTokenUrl();
+
+      const fetchOptions: any = !this.useCredentials
+        ? {
+            method: "POST",
+            headers: {
+              "User-Agent": UA,
+              Authorization: `Basic ${this.authorizationKey}`,
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: "grant_type=client_credentials",
+          }
+        : {
+            headers: {
+              Referer: "https://open.spotify.com/",
+              Origin: "https://open.spotify.com",
+            },
+          };
+
+      const token = await fetch(accessTokenUrl, fetchOptions).then((v) => v.json());
+
+      if (!token) throw new Error("Failed to retrieve access token.");
+
+      this.accessToken = {
+        token: token.accessToken,
+        expiresAfter: Date.now() + token.accessTokenExpirationTimestampMs,
+        type: "Bearer",
+      };
+    } catch (error) {
+      console.error("Error requesting Spotify access token:", error);
+      throw error;
     }
+  }
 
-    public async requestToken() {
-        try {
-            const res = await fetch(SP_ACCESS_TOKEN_URL, {
-                method: "POST",
-                headers: {
-                    "User-Agent": UA,
-                    Authorization: `Basic ${this.authorizationKey}`,
-                    "Content-Type": "application/x-www-form-urlencoded",
-                },
-                body: "grant_type=client_credentials",
-            });
-    
-            const body = await res.json();
-    
-            if (!body.access_token) 
-                throw new Error("Failed to retrieve access token.");
-          
-    
-            this.accessToken = {
-                token: body.access_token,
-                expiresAfter: Date.now() + body.expires_in * 1000,
-                type: "Bearer",
-            };
-        } catch (error) {
-            console.error("Error requesting Spotify access token:", error);
-            throw error;
-        }
+  private isTokenExpired() {
+    return !this.accessToken || Date.now() > this.accessToken.expiresAfter;
+  }
+
+  private async ensureValidToken() {
+    if (this.isTokenExpired()) await this.requestToken();
+  }
+
+  public async search(query: string) {
+    await this.ensureValidToken();
+
+    try {
+      const res = await fetch(`${SP_BASE}/search/?q=${encodeURIComponent(query)}&type=track&market=${this.market}`, {
+        headers: {
+          "User-Agent": UA,
+          Authorization: `${this.accessToken!.type} ${this.accessToken!.token}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!res.ok) throw new Error("Failed to search Spotify.");
+
+      const data: { tracks: { items: SpotifyTrack[] } } = await res.json();
+
+      return data.tracks.items.map((m) => ({
+        title: m.name,
+        duration: m.duration_ms,
+        artist: m.artists.map((artist) => artist.name).join(", "),
+        url: m.external_urls?.spotify || `https://open.spotify.com/track/${m.id}`,
+        thumbnail: m.album.images?.[0]?.url || null,
+      }));
+    } catch {
+      return null;
     }
+  }
 
-    private isTokenExpired() {
-        return !this.accessToken || Date.now() > this.accessToken.expiresAfter;
-    }
+  public async getPlaylist(id: string) {
+    if (!this.clientId || !this.clientSecret) throw new Error("Spotify clientId and clientSecret are required.");
 
-    private async ensureValidToken() {
-        if (this.isTokenExpired()) 
-            await this.requestToken();
-        
-    }
+    try {
+      await this.ensureValidToken();
 
-    public async search(query: string) {
-        await this.ensureValidToken();
+      const res = await fetch(`${SP_BASE}/playlists/${id}?market=${this.market}`, {
+        headers: {
+          "User-Agent": UA,
+          Authorization: `${this.accessToken!.type} ${this.accessToken!.token}`,
+          "Content-Type": "application/json",
+        },
+      });
+      if (!res.ok) return null;
 
-        try {
-            const res = await fetch(
-                `${SP_BASE}/search/?q=${encodeURIComponent(query)}&type=track&market=${this.market}`,
-                {
-                    headers: {
-                        "User-Agent": UA,
-                        Authorization: `${this.accessToken!.type} ${this.accessToken!.token}`,
-                        "Content-Type": "application/json",
-                    },
-                },
-            );
-
-            if (!res.ok) 
-                throw new Error("Failed to search Spotify.");
-      
-
-            const data: { tracks: { items: SpotifyTrack[] } } = await res.json();
-
-            return data.tracks.items.map((m) => ({
-                title: m.name,
-                duration: m.duration_ms,
-                artist: m.artists.map((artist) => artist.name).join(", "),
-                url:
-          m.external_urls?.spotify || `https://open.spotify.com/track/${m.id}`,
-                thumbnail: m.album.images?.[0]?.url || null,
-            }));
-        } catch {
-            return null;
-        }
-    }
-
-    public async getPlaylist(id: string) {
-        if (!this.clientId || !this.clientSecret) 
-            throw new Error("Spotify clientId and clientSecret are required.");
-
-        try {
-            await this.ensureValidToken();
-
-            const res = await fetch(`${SP_BASE}/playlists/${id}?market=${this.market}`, {
-                headers: {
-                    "User-Agent": UA,
-                    Authorization: `${this.accessToken!.type} ${this.accessToken!.token}`,
-                    "Content-Type": "application/json",
-                },
-            });
-            if (!res.ok) return null;
-
-            const data: {
+      const data: {
         external_urls: { spotify: string };
         owner: { display_name: string };
         id: string;
@@ -130,78 +130,74 @@ export class SpotifyAPI {
         };
       } = await res.json();
 
-            if (!data.tracks.items.length) return null;
+      if (!data.tracks.items.length) return null;
 
-            const t: { track: SpotifyTrack }[] = data.tracks.items;
+      const t: { track: SpotifyTrack }[] = data.tracks.items;
 
-            let next: string | undefined = data.tracks.next;
+      let next: string | undefined = data.tracks.next;
 
-            while (typeof next === "string") {
-                try {
-                    const nextRes = await fetch(next, {
-                        headers: {
-                            "User-Agent": UA,
-                            Authorization: `${this.accessToken!.type} ${this.accessToken!.token}`,
-                            "Content-Type": "application/json",
-                        },
-                    });
-                    if (!nextRes.ok) break;
-                    const nextPage: { items: { track: SpotifyTrack }[]; next?: string } =
-            await nextRes.json();
-
-                    t.push(...nextPage.items);
-                    next = nextPage.next;
-
-                    if (!next) break;
-                } catch {
-                    break;
-                }
-            }
-
-            const tracks = t.map(({ track: m }) => ({
-                name: m.name,
-                duration_ms: m.duration_ms,
-                artists: m.artists,
-                external_urls: m.external_urls,
-                id: m.id,
-                album: {
-                    images: m.album.images,
-                },
-            }));
-
-            if (!tracks.length) return null;
-            return {
-                name: data.name,
-                author: data.owner.display_name,
-                thumbnail: data.images?.[0]?.url || null,
-                id: data.id,
-                url:
-          data.external_urls.spotify ||
-          `https://open.spotify.com/playlist/${id}`,
-                tracks,
-            };
-        } catch (err) {
-            return null;
-        }
-    }
-
-    public async getAlbum(id: string) {
-        if (!this.clientId || !this.clientSecret) 
-            throw new Error("Spotify clientId and clientSecret are required.");
-
+      while (typeof next === "string") {
         try {
-            await this.ensureValidToken();
+          const nextRes = await fetch(next, {
+            headers: {
+              "User-Agent": UA,
+              Authorization: `${this.accessToken!.type} ${this.accessToken!.token}`,
+              "Content-Type": "application/json",
+            },
+          });
+          if (!nextRes.ok) break;
+          const nextPage: { items: { track: SpotifyTrack }[]; next?: string } = await nextRes.json();
 
-            const res = await fetch(`${SP_BASE}/albums/${id}?market=${this.market}`, {
-                headers: {
-                    "User-Agent": UA,
-                    Authorization: `${this.accessToken!.type} ${this.accessToken!.token}`,
-                    "Content-Type": "application/json",
-                },
-            });
-            if (!res.ok) return null;
+          t.push(...nextPage.items);
+          next = nextPage.next;
 
-            const data: {
+          if (!next) break;
+        } catch {
+          break;
+        }
+      }
+
+      const tracks = t.map(({ track: m }) => ({
+        name: m.name,
+        duration_ms: m.duration_ms,
+        artists: m.artists,
+        external_urls: m.external_urls,
+        id: m.id,
+        album: {
+          images: m.album.images,
+        },
+      }));
+
+      if (!tracks.length) return null;
+      return {
+        name: data.name,
+        author: data.owner.display_name,
+        thumbnail: data.images?.[0]?.url || null,
+        id: data.id,
+        url: data.external_urls.spotify || `https://open.spotify.com/playlist/${id}`,
+        tracks,
+      };
+    } catch (err) {
+      return null;
+    }
+  }
+
+  public async getAlbum(id: string) {
+    if (!this.clientId || !this.clientSecret) throw new Error("Spotify clientId and clientSecret are required.");
+
+    try {
+      await this.ensureValidToken();
+
+      const res = await fetch(`${SP_BASE}/albums/${id}?market=${this.market}`, {
+        headers: {
+          "User-Agent": UA,
+          Authorization: `${this.accessToken!.type} ${this.accessToken!.token}`,
+          "Content-Type": "application/json",
+        },
+      });
+      if (!res.ok) return null;
+
+      const data: {
         external_urls: { spotify: string };
         artists: { name: string }[];
         id: string;
@@ -213,91 +209,165 @@ export class SpotifyAPI {
         };
       } = await res.json();
 
-            if (!data.tracks.items.length) return null;
+      if (!data.tracks.items.length) return null;
 
-            const t: SpotifyTrack[] = data.tracks.items;
+      const t: SpotifyTrack[] = data.tracks.items;
 
-            let next: string | undefined = data.tracks.next;
+      let next: string | undefined = data.tracks.next;
 
-            while (typeof next === "string") {
-                try {
-                    const nextRes = await fetch(next, {
-                        headers: {
-                            "User-Agent": UA,
-                            Authorization: `${this.accessToken!.type} ${this.accessToken!.token}`,
-                            "Content-Type": "application/json",
-                        },
-                    });
-                    if (!nextRes.ok) break;
-                    const nextPage: { items: SpotifyTrack[]; next?: string } =
-            await nextRes.json();
-
-                    t.push(...nextPage.items);
-                    next = nextPage.next;
-
-                    if (!next) break;
-                } catch {
-                    break;
-                }
-            }
-
-            const tracks = t.map((m) => ({
-                name: m.name,
-                duration_ms: m.duration_ms,
-                artists: m.artists,
-                external_urls: m.external_urls,
-                id: m.id,
-                album: {
-                    images: data.images || [],
-                },
-            }));
-
-            if (!tracks.length) return null;
-            return {
-                name: data.name,
-                author: data.artists.map((m) => m.name).join(", "),
-                thumbnail: data.images?.[0]?.url || null,
-                id: data.id,
-                url:
-          data.external_urls.spotify || `https://open.spotify.com/album/${id}`,
-                tracks,
-            };
-        } catch {
-            return null;
-        }
-    }
-
-    public async getTrack(id: string) {
-        if (!this.clientId || !this.clientSecret) 
-            throw new Error("Spotify clientId and clientSecret are required.");
-
+      while (typeof next === "string") {
         try {
-            await this.ensureValidToken();
+          const nextRes = await fetch(next, {
+            headers: {
+              "User-Agent": UA,
+              Authorization: `${this.accessToken!.type} ${this.accessToken!.token}`,
+              "Content-Type": "application/json",
+            },
+          });
+          if (!nextRes.ok) break;
+          const nextPage: { items: SpotifyTrack[]; next?: string } = await nextRes.json();
 
-            const res = await fetch(`${SP_BASE}/tracks/${id}?market=${this.market}`, {
-                headers: {
-                    "User-Agent": UA,
-                    Authorization: `${this.accessToken!.type} ${this.accessToken!.token}`,
-                    "Content-Type": "application/json",
-                },
-            });
-            if (!res.ok) return null;
+          t.push(...nextPage.items);
+          next = nextPage.next;
 
-            const track: SpotifyTrack = await res.json();
-            return {
-                name: track.name,
-                duration_ms: track.duration_ms,
-                artists: track.artists,
-                external_urls: track.external_urls,
-                id: track.id,
-                album: {
-                    images: track.album.images,
-                },
-            };
+          if (!next) break;
         } catch {
-            return null;
+          break;
         }
+      }
+
+      const tracks = t.map((m) => ({
+        name: m.name,
+        duration_ms: m.duration_ms,
+        artists: m.artists,
+        external_urls: m.external_urls,
+        id: m.id,
+        album: {
+          images: data.images || [],
+        },
+      }));
+
+      if (!tracks.length) return null;
+      return {
+        name: data.name,
+        author: data.artists.map((m) => m.name).join(", "),
+        thumbnail: data.images?.[0]?.url || null,
+        id: data.id,
+        url: data.external_urls.spotify || `https://open.spotify.com/album/${id}`,
+        tracks,
+      };
+    } catch {
+      return null;
     }
+  }
+
+  public async getTrack(id: string) {
+    if (!this.clientId || !this.clientSecret) throw new Error("Spotify clientId and clientSecret are required.");
+
+    try {
+      await this.ensureValidToken();
+
+      const res = await fetch(`${SP_BASE}/tracks/${id}?market=${this.market}`, {
+        headers: {
+          "User-Agent": UA,
+          Authorization: `${this.accessToken!.type} ${this.accessToken!.token}`,
+          "Content-Type": "application/json",
+        },
+      });
+      if (!res.ok) return null;
+
+      const track: SpotifyTrack = await res.json();
+      return {
+        name: track.name,
+        duration_ms: track.duration_ms,
+        artists: track.artists,
+        external_urls: track.external_urls,
+        id: track.id,
+        album: {
+          images: track.album.images,
+        },
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private buildTokenUrl() {
+    const baseUrl = new URL("https://open.spotify.com/get_access_token");
+    baseUrl.searchParams.set("reason", "init");
+    baseUrl.searchParams.set("productType", "web-player");
+    return baseUrl;
+  }
+
+  private calculateToken(hex: Array<number>) {
+    const token = hex.map((v, i) => v ^ ((i % 33) + 9));
+    const bufferToken = Buffer.from(token.map((v) => String.fromCharCode(v)).join(""), "utf8").toString("hex");
+    return bufferToken;
+  }
+
+  private async getAccessTokenUrl() {
+    if (this.useCredentials) return "https://accounts.spotify.com/api/token?grant_type=client_credentials";
+
+    const token = this.calculateToken([12, 56, 76, 33, 88, 44, 88, 33, 78, 78, 11, 66, 22, 22, 55, 69, 54]);
+
+    const spotifyHtml = await fetch("https://open.spotify.com", {
+      headers: {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
+      },
+    }).then((v) => v.text());
+    const $ = cheerio.load(spotifyHtml);
+
+    const scriptTags = $("script").toArray();
+    const playerSrc = scriptTags.filter((v) => v.attribs.src?.includes("web-player/web-player."))[0].attribs.src;
+    const playerScript = await fetch(playerSrc, {
+      headers: {
+        Dnt: "1",
+        Referer: "https://open.spotify.com/",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
+      },
+    }).then((v) => v.text());
+
+    const playerVerSplit = playerScript.split("buildVer");
+    const versionString = `{"buildVer"${playerVerSplit[1].split("}")[0].replace("buildDate", '"buildDate"')}}`;
+    const version = JSON.parse(versionString);
+
+    const url = this.buildTokenUrl();
+    const { searchParams } = url;
+
+    const cTime = Date.now();
+    const sTime = await fetch("https://open.spotify.com/server-time", {
+      headers: {
+        Referer: "https://open.spotify.com/",
+        Origin: "https://open.spotify.com",
+      },
+    })
+      .then((v) => v.json())
+      .then((v) => v.serverTime);
+
+    const totp = new TOTP({
+      secret: token,
+      period: 30,
+      digits: 6,
+      algorithm: "SHA1",
+    });
+
+    const totpServer = totp.generate({
+      timestamp: sTime * 1e3,
+    });
+    const totpClient = totp.generate({
+      timestamp: cTime,
+    });
+
+    searchParams.set("sTime", String(sTime));
+    searchParams.set("cTime", String(cTime));
+    searchParams.set("totp", totpClient);
+    searchParams.set("totpServer", totpServer);
+    searchParams.set("totpVer", "5");
+    searchParams.set("buildVer", version.buildVer);
+    searchParams.set("buildDate", version.buildDate);
+
+    return url;
+  }
 }
 
 export interface SpotifyTrack {

--- a/src/internal/spotify.ts
+++ b/src/internal/spotify.ts
@@ -1,6 +1,6 @@
 import { Secret, TOTP } from "otpauth";
 import { UA, market } from "./helper";
-import * as cheerio from "cheerio";
+import { parse } from "node-html-parser";
 import { Buffer } from "node:buffer";
 
 const SP_BASE = "https://api.spotify.com/v1";
@@ -278,9 +278,10 @@ export class SpotifyAPI {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
       },
     }).then((v) => v.text());
-    const $ = cheerio.load(spotifyHtml);
-    const scriptTags = $("script").toArray();
-    const playerSrc = scriptTags.filter((v) => v.attribs.src?.includes("web-player/web-player."))[0].attribs.src;
+    const root = parse(spotifyHtml);
+    const scriptTags = root.querySelectorAll("script");
+    const playerSrc = scriptTags.find((v) => v.getAttribute("src")?.includes("web-player/web-player."))?.getAttribute("src");
+    if (!playerSrc) throw new Error("Could not find player script source");
     const playerScript = await fetch(playerSrc, {
       headers: {
         Dnt: "1",


### PR DESCRIPTION
Now anonymous auth will be used by default unless Spotify web API credentials are provided.
The default market is set to empty (not sure what this means but can always specify it in options).

Added support for Spotify mix playlists but only when no credentials are provided (using anonymous token).