### PR TITLE
Adds related track fetching using Spotify API with fallback and deduplication

### DIFF
--- a/src/internal/spotify.ts
+++ b/src/internal/spotify.ts
@@ -260,7 +260,7 @@ export class SpotifyAPI {
       if (this.useCredentials) throw new Error("getRecommendations endpoint is not supported when using credentials.");
 
       const res = await this.fetchData(
-        `${SP_BASE}/recommendations/?seed_tracks=${trackIds.join(",")}&limit=${limit || "20-100"}${this.market ? `&market=${this.market}` : ""}`
+        `${SP_BASE}/recommendations/?seed_tracks=${trackIds.join(",")}&limit=${limit || "100"}${this.market ? `&market=${this.market}` : ""}`
       );
       if (!res) return null;
       const data: { tracks: SpotifyTrack[] } = await res.json();


### PR DESCRIPTION
When using credentials, the /search endpoint is used to fetch tracks by a random artist selected from the last 25 tracks in history.

When using the anonymous token, the /recommendations endpoint is used with 5 random seed tracks from the last 25 tracks in history.

If the recommendations request fails, it falls back to artist-based search using one of the recent artists.

All results are filtered to exclude any tracks already in history, matching against the last N tracks where N is the length of the fetched results.