### PR TITLE
fix: unavailable tracks in playlist/album

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ await player.extractors.register(SpotifyExtractor, { /* options */ });
 | --- | --- | --- | --- | --- |
 | clientId | string | null | No | Your Spotify client id |
 | clientSecret | string | null | No | Your Spotify client secret |
-| market | string | "" | No | The market to use for the Spotify API. |
+| market | string | "US" | No | The market to use for the Spotify API. |
 | createStream(ext: SpotifyExtractor, url: string) => Promise<Readable \| string>; | function | null | No | A function that returns a Readable stream or a string URL to the stream. |
 
 [Information on the market parameter and the reason why it is required.](https://developer.spotify.com/documentation/web-api/concepts/track-relinking)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ await player.extractors.register(SpotifyExtractor, { /* options */ });
 | --- | --- | --- | --- | --- |
 | clientId | string | null | No | Your Spotify client id |
 | clientSecret | string | null | No | Your Spotify client secret |
-| market | string | "US" | No | The market to use for the Spotify API. |
+| market | string | US | No | The market to use for the Spotify API. |
 | createStream(ext: SpotifyExtractor, url: string) => Promise<Readable \| string>; | function | null | No | A function that returns a Readable stream or a string URL to the stream. |
 
 [Information on the market parameter and the reason why it is required.](https://developer.spotify.com/documentation/web-api/concepts/track-relinking)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ const player = new Player(client, {});
 await player.extractors.register(SpotifyExtractor, { /* options */ });
 ```
 
+## Supported features
+
+| Feature | Supported |
+| --- | --- |
+| Single tracks | ✅ |
+| Playlists | ✅ |
+| Search | ✅ |
+| Direct streaming | ❌ |
+| Can be used as a bridge | ❌ |
+| Can bridge to ... | ✅ |
+| Autoplay | ✅* |
+
+\* Autoplay works differently whether you use credentials or not.
+
 ## Options
 
 | Option | Type | Default | Required | Description |

--- a/README.md
+++ b/README.md
@@ -22,27 +22,13 @@ const player = new Player(client, {});
 await player.extractors.register(SpotifyExtractor, { /* options */ });
 ```
 
-## Supported features
-
-| Feature | Supported |
-| --- | --- |
-| Single tracks | ✅ |
-| Playlists | ✅ |
-| Search | ✅ |
-| Direct streaming | ❌ |
-| Can be used as a bridge | ❌ |
-| Can bridge to ... | ✅ |
-| Autoplay | ✅* |
-
-\* Autoplay works differently weither you use credentials or not.
-
 ## Options
 
 | Option | Type | Default | Required | Description |
 | --- | --- | --- | --- | --- |
 | clientId | string | null | No | Your Spotify client id |
 | clientSecret | string | null | No | Your Spotify client secret |
-| market | string | US | No | The market to use for the Spotify API. |
+| market | string | "" | No | The market to use for the Spotify API. |
 | createStream(ext: SpotifyExtractor, url: string) => Promise<Readable \| string>; | function | null | No | A function that returns a Readable stream or a string URL to the stream. |
 
 [Information on the market parameter and the reason why it is required.](https://developer.spotify.com/documentation/web-api/concepts/track-relinking)

--- a/src/internal/helper.ts
+++ b/src/internal/helper.ts
@@ -1,7 +1,7 @@
 export const UA =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 Edg/109.0.1518.49";
 
-export const market = "US";
+export const market = "";
 
 export const spotifyUrlRegex = 
   /^(?:https:\/\/open\.spotify\.com\/(intl-([a-z]|[A-Z]){0,3}\/)?(?:user\/[A-Za-z0-9]+\/)?|spotify:)(album|playlist|track)(?:[/:])([A-Za-z0-9]+).*$/;

--- a/src/internal/helper.ts
+++ b/src/internal/helper.ts
@@ -1,7 +1,7 @@
 export const UA =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 Edg/109.0.1518.49";
 
-export const market = "";
+export const market = "US";
 
 export const spotifyUrlRegex = 
   /^(?:https:\/\/open\.spotify\.com\/(intl-([a-z]|[A-Z]){0,3}\/)?(?:user\/[A-Za-z0-9]+\/)?|spotify:)(album|playlist|track)(?:[/:])([A-Za-z0-9]+).*$/;

--- a/src/internal/spotify.ts
+++ b/src/internal/spotify.ts
@@ -91,7 +91,7 @@ export class SpotifyAPI {
 
     public async search(query: string) {
         try {
-            const res = await this.fetchData(`${SP_BASE}/search/?q=${encodeURIComponent(query)}&type=track${this.market ? `&market=${this.market}` : ""}`);
+            const res = await this.fetchData(`${SP_BASE}/search/?q=${encodeURIComponent(query)}&type=track&market=${this.market}`);
             const data: { tracks: { items: SpotifyTrack[] } } = await res.json();
 
             return data.tracks.items.map((m) => ({
@@ -108,7 +108,7 @@ export class SpotifyAPI {
 
     public async getPlaylist(id: string) {
         try {
-            const res = await this.fetchData(`${SP_BASE}/playlists/${id}${this.market ? `&market=${this.market}` : ""}`);
+            const res = await this.fetchData(`${SP_BASE}/playlists/${id}?market=${this.market}`);
             if (!res) return null;
 
             const data: {
@@ -173,7 +173,7 @@ export class SpotifyAPI {
         if (!this.clientId || !this.clientSecret) throw new Error("Spotify clientId and clientSecret are required.");
 
         try {
-            const res = await this.fetchData(`${SP_BASE}/albums/${id}${this.market ? `&market=${this.market}` : ""}`);
+            const res = await this.fetchData(`${SP_BASE}/albums/${id}?market=${this.market}`);
             if (!res) return null;
 
             const data: {
@@ -236,7 +236,7 @@ export class SpotifyAPI {
 
     public async getTrack(id: string) {
         try {
-            const res = await this.fetchData(`${SP_BASE}/tracks/${id}${this.market ? `&market=${this.market}` : ""}`);
+            const res = await this.fetchData(`${SP_BASE}/tracks/${id}?market=${this.market}`);
             if (!res) return null;
 
             const track: SpotifyTrack = await res.json();
@@ -260,7 +260,7 @@ export class SpotifyAPI {
             if (this.useCredentials) throw new Error("getRecommendations endpoint is not supported when using credentials.");
 
             const res = await this.fetchData(
-                `${SP_BASE}/recommendations/?seed_tracks=${trackIds.join(",")}&limit=${limit || "100"}${this.market ? `&market=${this.market}` : ""}`,
+                `${SP_BASE}/recommendations/?seed_tracks=${trackIds.join(",")}&limit=${limit || "100"}&market=${this.market}`,
             );
             if (!res) return null;
             const data: { tracks: SpotifyTrack[] } = await res.json();

--- a/src/internal/spotify.ts
+++ b/src/internal/spotify.ts
@@ -91,7 +91,7 @@ export class SpotifyAPI {
 
     public async search(query: string) {
         try {
-            const res = await this.fetchData(`${SP_BASE}/search/?q=${encodeURIComponent(query)}&type=track&market=${this.market}`);
+            const res = await this.fetchData(`${SP_BASE}/search/?q=${encodeURIComponent(query)}&type=track${this.market ? `&market=${this.market}` : ""}`);
             const data: { tracks: { items: SpotifyTrack[] } } = await res.json();
 
             return data.tracks.items.map((m) => ({
@@ -108,7 +108,7 @@ export class SpotifyAPI {
 
     public async getPlaylist(id: string) {
         try {
-            const res = await this.fetchData(`${SP_BASE}/playlists/${id}?market=${this.market}`);
+            const res = await this.fetchData(`${SP_BASE}/playlists/${id}${this.market ? `?market=${this.market}` : ""}`);
             if (!res) return null;
 
             const data: {
@@ -144,7 +144,9 @@ export class SpotifyAPI {
                 }
             }
 
-            const tracks = t.map(({ track: m }) => ({
+            const tracks = t
+            .filter(({ track: m }) => m?.name && m?.artists)
+            .map(({ track: m }) => ({
                 name: m.name,
                 duration_ms: m.duration_ms,
                 artists: m.artists,
@@ -173,7 +175,7 @@ export class SpotifyAPI {
         if (!this.clientId || !this.clientSecret) throw new Error("Spotify clientId and clientSecret are required.");
 
         try {
-            const res = await this.fetchData(`${SP_BASE}/albums/${id}?market=${this.market}`);
+            const res = await this.fetchData(`${SP_BASE}/albums/${id}${this.market ? `?market=${this.market}` : ""}`);
             if (!res) return null;
 
             const data: {
@@ -209,7 +211,9 @@ export class SpotifyAPI {
                 }
             }
 
-            const tracks = t.map((m) => ({
+            const tracks = t
+            .filter(( m ) => m?.name && m?.artists)
+            .map((m) => ({
                 name: m.name,
                 duration_ms: m.duration_ms,
                 artists: m.artists,
@@ -236,7 +240,7 @@ export class SpotifyAPI {
 
     public async getTrack(id: string) {
         try {
-            const res = await this.fetchData(`${SP_BASE}/tracks/${id}?market=${this.market}`);
+            const res = await this.fetchData(`${SP_BASE}/tracks/${id}${this.market ? `?market=${this.market}` : ""}`);
             if (!res) return null;
 
             const track: SpotifyTrack = await res.json();
@@ -260,7 +264,7 @@ export class SpotifyAPI {
             if (this.useCredentials) throw new Error("getRecommendations endpoint is not supported when using credentials.");
 
             const res = await this.fetchData(
-                `${SP_BASE}/recommendations/?seed_tracks=${trackIds.join(",")}&limit=${limit || "100"}&market=${this.market}`,
+                `${SP_BASE}/recommendations/?seed_tracks=${trackIds.join(",")}&limit=${limit || "100"}${this.market ? `&market=${this.market}` : ""}`,
             );
             if (!res) return null;
             const data: { tracks: SpotifyTrack[] } = await res.json();


### PR DESCRIPTION
Added a filter to ensure that both track name and artist fields have values before mapping. This prevents entire playlists or albums from failing to add tracks when most of the tracks are still available.