### PR TITLE
add spotify anon token fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 *.log
 .vscode/
 tinker.ts
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -51,6 +51,5 @@
     "acorn": "^8.16.0",
     "node-html-parser": "^7.0.1",
     "otpauth": "^9.3.6"
-  },
-  "packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "acorn": "^8.16.0",
     "node-html-parser": "^7.0.1",
     "otpauth": "^9.3.6"
-  }
+  },
+  "packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017"
 }

--- a/src/SpotifyExtractor.ts
+++ b/src/SpotifyExtractor.ts
@@ -3,6 +3,7 @@ import { BaseExtractor, ExtractorInfo, ExtractorSearchContext, ExtractorStreamab
 import type { Readable } from "stream";
 import { SpotifyAPI } from "./internal/spotify";
 import { spotifySongRegex, spotifyPlaylistRegex, spotifyAlbumRegex, isUrl, parseSpotifyUrl, market } from "./internal/helper";
+import { grabSpotifyAnonToken } from "./internal/grabSpotifyToken";
 import { User } from "discord.js";
 
 type StreamFN = (url: string, track: Track) => Promise<Readable | string>;
@@ -14,7 +15,7 @@ export interface SpotifyExtractorInit {
   createStream?: (ext: SpotifyExtractor, url: string) => Promise<Readable | string>;
 }
 
-export { parseSpotifyUrl };
+export { parseSpotifyUrl, grabSpotifyAnonToken };
 
 export class SpotifyExtractor extends BaseExtractor<SpotifyExtractorInit> {
     public static identifier = "com.discord-player.itsmaat.spotifyextractor" as const;

--- a/src/internal/grabSpotifyToken.ts
+++ b/src/internal/grabSpotifyToken.ts
@@ -17,7 +17,7 @@ function transformSecret(secret: string) {
     return hex;
 }
 
-export interface AnonmousSpotifyTokenResponse {
+export interface AnonymousSpotifyTokenResponse {
     clientId: string;
     accessToken: string;
     accessTokenExpirationTimestampMs: number;
@@ -147,7 +147,7 @@ export async function grabSpotifyAnonToken() {
     });
 
     return {
-        tokens: tokenResponse as AnonmousSpotifyTokenResponse,
+        tokens: tokenResponse as AnonymousSpotifyTokenResponse,
         secrets: parsedSecret // cache this for around 6 hours
     }
 }

--- a/src/internal/grabSpotifyToken.ts
+++ b/src/internal/grabSpotifyToken.ts
@@ -1,0 +1,153 @@
+import { parse } from "node-html-parser";
+import * as acorn from "acorn"
+import { TOTP, Secret } from "otpauth";
+
+const USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36";
+
+const SPOTIFY_URLS = [
+    "https://open.spotify.com/album/7vI4iTxDmgEN63liQHPEX1",
+    "https://open.spotify.com/album/7kFyd5oyJdVX2pIi6P4iHE",
+    "https://open.spotify.com/album/6s84u2TUpR3wdUv4NgKA2j"
+]
+
+function transformSecret(secret: string) {
+    const shuffle = secret.split("").map((char, index) => char.charCodeAt(0) ^ index % 33 + 9);
+    const hex = Buffer.from(shuffle.join(""), "utf8").toString("hex");
+
+    return hex;
+}
+
+export interface AnonmousSpotifyTokenResponse {
+    clientId: string;
+    accessToken: string;
+    accessTokenExpirationTimestampMs: number;
+    isAnonymous: true;
+}
+
+function jsLiteralToObject(str: string) {
+    const ast = acorn.parse(str, { ecmaVersion: "latest" });
+    const arrays: { secret: string, version: number }[] = [];
+
+    const converter = (node: acorn.Node) => {
+        switch (node.type) {
+            case "ObjectExpression": {
+                const obj: Record<string, unknown> = {};
+                // @ts-expect-error properties does exist
+                for (const prop of node.properties) {
+                    if (prop.type === "Property" && prop.key.type === "Identifier") {
+                        obj[prop.key.name] = converter(prop.value);
+                    }
+                }
+                return obj;
+            }
+            case "ArrayExpression": {
+                // @ts-expect-error element does exists
+                return node.elements.map(converter);
+            }
+            case "Literal": {
+                // @ts-expect-error value does exists
+                return node.value;
+            }
+            default:
+                return null;
+        }
+    }
+
+    const astWalker = (node?: acorn.Node) => {
+        if (!node || typeof node !== "object") return;
+        if (node.type === "ArrayExpression") {
+            arrays.push(converter(node));
+        }
+
+        for (const key in node) {
+            const value = node[key as keyof acorn.Node];
+            // @ts-ignore we know this is an array of nodes, but acorn's types don't reflect that
+            if (Array.isArray(value)) value.forEach(astWalker);
+            // @ts-ignore we know this is an array of nodes, but acorn's types don't reflect that
+            else astWalker(value);
+        }
+    }
+
+    astWalker(ast);
+
+    return arrays[0] as unknown as { secret: string, version: number }[];
+}
+
+export async function grabSpotifyAnonToken() {
+    const spotifyHTML = await fetch(SPOTIFY_URLS[Math.floor(Math.random() * SPOTIFY_URLS.length)], {
+        headers: {
+            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
+        }
+    })
+        .then(res => {
+            if (!res.ok) throw new Error(`Failed to fetch Spotify page: ${res.statusText}`);
+            return res.text();
+        });
+
+    const parsed = parse(spotifyHTML);
+
+    const scriptTags = parsed.querySelectorAll("script");
+
+    const webPlayer = scriptTags.find(tag => tag.attributes.src?.includes("web-player."));
+
+    if (!webPlayer) {
+        throw new Error("Unable to extract web player script");
+    }
+
+    const webPlayerUrl = webPlayer.attributes.src;
+    const webPlayerScript = await fetch(webPlayerUrl, {
+        headers: {
+            "User-Agent": USER_AGENT
+        }
+    }).then(res => {
+        if (!res.ok) throw new Error(`Failed to fetch web player script: ${res.statusText}`);
+        return res.text();
+    });
+
+    const arrayWithObjectRegex = /\[(?:[^\[\]]|\[[^\[\]]*\])*\]/gm;
+
+    const allArrays = webPlayerScript.match(arrayWithObjectRegex)?.filter(v => v.includes("secret"))
+    const secret = allArrays?.[0];
+
+    if (!secret) throw new Error("Unable to extract secret");
+
+    const parsedSecret = jsLiteralToObject(secret).map(v => ({ secret: transformSecret(v.secret), version: v.version }));
+
+    const totp = new TOTP({
+        algorithm: "SHA1",
+        digits: 6,
+        period: 30,
+        secret: Secret.fromHex(parsedSecret[0].secret)
+    });
+
+    const serverTime = Math.floor(Date.now() / 1000);
+    const totpClient = totp.generate();
+    const totpServer = totp.generate({
+        timestamp: serverTime
+    });
+
+    const url = new URL("https://open.spotify.com/api/token");
+    const searchParams = url.searchParams;
+
+    searchParams.set("reason", "init");
+    searchParams.set("productType", "web-player");
+    searchParams.set("totp", totpClient);
+    searchParams.set("totpServer", totpServer);
+    searchParams.set("totpVer", parsedSecret[0].version.toString());
+
+    console.log("SPOTIFY TOKEN URL", url.toString());
+
+    const tokenResponse = await fetch(url.toString(), {
+        headers: {
+            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
+        }
+    }).then(res => {
+        if (!res.ok) throw new Error(`Failed to fetch Spotify token: ${res.statusText}`);
+        return res.json();
+    });
+
+    return {
+        tokens: tokenResponse as AnonmousSpotifyTokenResponse,
+        secrets: parsedSecret // cache this for around 6 hours
+    }
+}

--- a/src/internal/grabSpotifyToken.ts
+++ b/src/internal/grabSpotifyToken.ts
@@ -70,54 +70,58 @@ function jsLiteralToObject(str: string) {
 
     astWalker(ast);
 
-    return arrays[0] as unknown as { secret: string, version: number }[];
+    return arrays[0] as unknown as SpotifySecret[];
 }
+export type SpotifySecret = { secret: string, version: number }
+export async function grabSpotifyAnonToken(sec?: SpotifySecret[]) {
+    let secret: SpotifySecret[] | undefined = sec;
 
-export async function grabSpotifyAnonToken() {
-    const spotifyHTML = await fetch(SPOTIFY_URLS[Math.floor(Math.random() * SPOTIFY_URLS.length)], {
-        headers: {
-            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
+    if (!secret) {
+        const spotifyHTML = await fetch(SPOTIFY_URLS[Math.floor(Math.random() * SPOTIFY_URLS.length)], {
+            headers: {
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
+            }
+        })
+            .then(res => {
+                if (!res.ok) throw new Error(`Failed to fetch Spotify page: ${res.statusText}`);
+                return res.text();
+            });
+
+        const parsed = parse(spotifyHTML);
+
+        const scriptTags = parsed.querySelectorAll("script");
+
+        const webPlayer = scriptTags.find(tag => tag.attributes.src?.includes("web-player."));
+
+        if (!webPlayer) {
+            throw new Error("Unable to extract web player script");
         }
-    })
-        .then(res => {
-            if (!res.ok) throw new Error(`Failed to fetch Spotify page: ${res.statusText}`);
+
+        const webPlayerUrl = webPlayer.attributes.src;
+        const webPlayerScript = await fetch(webPlayerUrl, {
+            headers: {
+                "User-Agent": USER_AGENT
+            }
+        }).then(res => {
+            if (!res.ok) throw new Error(`Failed to fetch web player script: ${res.statusText}`);
             return res.text();
         });
 
-    const parsed = parse(spotifyHTML);
+        const arrayWithObjectRegex = /\[(?:[^\[\]]|\[[^\[\]]*\])*\]/gm;
 
-    const scriptTags = parsed.querySelectorAll("script");
+        const allArrays = webPlayerScript.match(arrayWithObjectRegex)?.filter(v => v.includes("secret"))
+        const secretRaw = allArrays?.[0];
 
-    const webPlayer = scriptTags.find(tag => tag.attributes.src?.includes("web-player."));
+        if (!secretRaw) throw new Error("Unable to extract secret");
 
-    if (!webPlayer) {
-        throw new Error("Unable to extract web player script");
+        secret = jsLiteralToObject(secretRaw).map(v => ({ secret: transformSecret(v.secret), version: v.version }));
     }
-
-    const webPlayerUrl = webPlayer.attributes.src;
-    const webPlayerScript = await fetch(webPlayerUrl, {
-        headers: {
-            "User-Agent": USER_AGENT
-        }
-    }).then(res => {
-        if (!res.ok) throw new Error(`Failed to fetch web player script: ${res.statusText}`);
-        return res.text();
-    });
-
-    const arrayWithObjectRegex = /\[(?:[^\[\]]|\[[^\[\]]*\])*\]/gm;
-
-    const allArrays = webPlayerScript.match(arrayWithObjectRegex)?.filter(v => v.includes("secret"))
-    const secret = allArrays?.[0];
-
-    if (!secret) throw new Error("Unable to extract secret");
-
-    const parsedSecret = jsLiteralToObject(secret).map(v => ({ secret: transformSecret(v.secret), version: v.version }));
 
     const totp = new TOTP({
         algorithm: "SHA1",
         digits: 6,
         period: 30,
-        secret: Secret.fromHex(parsedSecret[0].secret)
+        secret: Secret.fromHex(secret[0].secret)
     });
 
     const serverTime = Math.floor(Date.now() / 1000);
@@ -133,9 +137,7 @@ export async function grabSpotifyAnonToken() {
     searchParams.set("productType", "web-player");
     searchParams.set("totp", totpClient);
     searchParams.set("totpServer", totpServer);
-    searchParams.set("totpVer", parsedSecret[0].version.toString());
-
-    console.log("SPOTIFY TOKEN URL", url.toString());
+    searchParams.set("totpVer", secret[0].version.toString());
 
     const tokenResponse = await fetch(url.toString(), {
         headers: {
@@ -148,6 +150,6 @@ export async function grabSpotifyAnonToken() {
 
     return {
         tokens: tokenResponse as AnonymousSpotifyTokenResponse,
-        secrets: parsedSecret // cache this for around 6 hours
+        secrets: secret // cache this for around 6 hours
     }
 }


### PR DESCRIPTION
This PR adds a helper function to fetch Spotify anonymous tokens.
# A few things to note:
- I am using an AST walker which means parsing of JavaScript string into actual usable objects will be a bit slow (but not that slow) but safe
- This adds the dependency acorn for JavaScript AST walking
- This does not implement the tokens generated in the actual extractor but only provides a function

Also fixes #6 and acts as the replacement for #7. This probably could use a puppeteer based fallback system though.