### PR TITLE
reworked spotify anon method

### DIFF
--- a/src/SpotifyExtractor.ts
+++ b/src/SpotifyExtractor.ts
@@ -3,7 +3,7 @@ import { BaseExtractor, ExtractorInfo, ExtractorSearchContext, ExtractorStreamab
 import type { Readable } from "stream";
 import { SpotifyAPI } from "./internal/spotify";
 import { spotifySongRegex, spotifyPlaylistRegex, spotifyAlbumRegex, isUrl, parseSpotifyUrl, market } from "./internal/helper";
-import { grabSpotifyAnonToken } from "./internal/grabSpotifyToken";
+import { grabSpotifyAnonToken, type AnonTokenData } from "./internal/grabSpotifyToken";
 import { User } from "discord.js";
 
 type StreamFN = (url: string, track: Track) => Promise<Readable | string>;
@@ -15,7 +15,7 @@ export interface SpotifyExtractorInit {
   createStream?: (ext: SpotifyExtractor, url: string) => Promise<Readable | string>;
 }
 
-export { parseSpotifyUrl, grabSpotifyAnonToken };
+export { parseSpotifyUrl, grabSpotifyAnonToken, type AnonTokenData };
 
 export class SpotifyExtractor extends BaseExtractor<SpotifyExtractorInit> {
     public static identifier = "com.discord-player.itsmaat.spotifyextractor" as const;
@@ -225,25 +225,22 @@ export class SpotifyExtractor extends BaseExtractor<SpotifyExtractorInit> {
     public async getRelatedTracks(track: Track, history: GuildQueueHistory): Promise<ExtractorInfo> {
         let relatedTracks: { title: string; duration: number; artist: string; url: string; thumbnail: string | null }[] | null = null;
         if (!this.internal.useCredentials) {
-            const trackIds = Array.from(
+            const trackIds: string[] = Array.from(
                 new Set(
                     history.tracks
                         .toArray()
                         .filter((t: Track) => t.url.includes("spotify.com"))
-                        .slice(0, 25)
-                        .map((t: Track) => {
-                            const lastSegment = t.url.split("/").at(-1);
-                            return lastSegment ? lastSegment.split("?").at(0) : null;
-                        })
-                        .filter((id): id is string => id !== null),
+                        .map((t: Track) => t.url.split("/").at(-1)?.split("?").at(0))
+                        .filter((id): id is string => !!id),
                 ),
             )
                 .sort(() => 0.5 - Math.random())
                 .slice(0, 5);
-            if (trackIds.length) 
-                relatedTracks = await this.internal.getRecommendations(trackIds);
-      
+            if (trackIds.length)
+                // TODO: implement a way to fetch recommendations using anonymous token - returns empty array at the moment
+                relatedTracks = await this.internal.getRecommendations(trackIds); 
         }
+
         if (this.internal.useCredentials || !relatedTracks?.length) {
             const artist = Array.from(
                 new Set(
@@ -257,9 +254,8 @@ export class SpotifyExtractor extends BaseExtractor<SpotifyExtractorInit> {
                 .sort(() => 0.5 - Math.random())
                 .slice(0, 1);
 
-            if (artist) 
+            if (artist.length)
                 relatedTracks = await this.internal.search(`artist:${artist}`);
-      
         }
 
         if (!relatedTracks?.length) {

--- a/src/internal/grabSpotifyToken.ts
+++ b/src/internal/grabSpotifyToken.ts
@@ -1,20 +1,19 @@
 import { parse } from "node-html-parser";
-import * as acorn from "acorn"
+import * as acorn from "acorn";
 import { TOTP, Secret } from "otpauth";
+import { Buffer } from "node:buffer";
 
 const USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36";
 
 const SPOTIFY_URLS = [
     "https://open.spotify.com/album/7vI4iTxDmgEN63liQHPEX1",
     "https://open.spotify.com/album/7kFyd5oyJdVX2pIi6P4iHE",
-    "https://open.spotify.com/album/6s84u2TUpR3wdUv4NgKA2j"
-]
+    "https://open.spotify.com/album/6s84u2TUpR3wdUv4NgKA2j",
+];
 
-function transformSecret(secret: string) {
+function transformSecret(secret: string): string {
     const shuffle = secret.split("").map((char, index) => char.charCodeAt(0) ^ index % 33 + 9);
-    const hex = Buffer.from(shuffle.join(""), "utf8").toString("hex");
-
-    return hex;
+    return Buffer.from(shuffle.join(""), "utf8").toString("hex");
 }
 
 export interface AnonymousSpotifyTokenResponse {
@@ -24,132 +23,156 @@ export interface AnonymousSpotifyTokenResponse {
     isAnonymous: true;
 }
 
-function jsLiteralToObject(str: string) {
-    const ast = acorn.parse(str, { ecmaVersion: "latest" });
-    const arrays: { secret: string, version: number }[] = [];
+export interface AnonTokenData {
+    tokens: AnonymousSpotifyTokenResponse;
+    clientToken: string;
+    clientVersion: string;
+    secrets: SpotifySecret[];
+}
 
-    const converter = (node: acorn.Node) => {
+export type SpotifySecret = { secret: string; version: number };
+
+interface SPClientTokenResponse {
+    granted_token: { token: string };
+}
+
+function jsLiteralToObject(str: string): SpotifySecret[] {
+    const ast = acorn.parse(str, { ecmaVersion: "latest" });
+    const arrays: unknown[] = [];
+
+    const converter = (node: acorn.Node): unknown => {
         switch (node.type) {
             case "ObjectExpression": {
                 const obj: Record<string, unknown> = {};
                 // @ts-expect-error properties does exist
                 for (const prop of node.properties) {
-                    if (prop.type === "Property" && prop.key.type === "Identifier") {
+                    if (prop.type === "Property" && prop.key.type === "Identifier") 
                         obj[prop.key.name] = converter(prop.value);
-                    }
+                    
                 }
                 return obj;
             }
-            case "ArrayExpression": {
-                // @ts-expect-error element does exists
+            case "ArrayExpression":
+                // @ts-expect-error elements does exist
                 return node.elements.map(converter);
-            }
-            case "Literal": {
-                // @ts-expect-error value does exists
+            case "Literal":
+                // @ts-expect-error value does exist
                 return node.value;
-            }
             default:
                 return null;
         }
-    }
+    };
 
-    const astWalker = (node?: acorn.Node) => {
+    const astWalker = (node?: acorn.Node): void => {
         if (!node || typeof node !== "object") return;
-        if (node.type === "ArrayExpression") {
-            arrays.push(converter(node));
-        }
-
+        if (node.type === "ArrayExpression") arrays.push(converter(node));
         for (const key in node) {
             const value = node[key as keyof acorn.Node];
-            // @ts-ignore we know this is an array of nodes, but acorn's types don't reflect that
+            // @ts-expect-error we know this is an array of nodes, but acorn's types don't reflect that
             if (Array.isArray(value)) value.forEach(astWalker);
-            // @ts-ignore we know this is an array of nodes, but acorn's types don't reflect that
+            // @ts-expect-error we know this is an array of nodes, but acorn's types don't reflect that
             else astWalker(value);
         }
-    }
+    };
 
     astWalker(ast);
-
-    return arrays[0] as unknown as SpotifySecret[];
+    return arrays[0] as SpotifySecret[];
 }
-export type SpotifySecret = { secret: string, version: number }
-export async function grabSpotifyAnonToken(sec?: SpotifySecret[]) {
-    let secret: SpotifySecret[] | undefined = sec;
 
-    if (!secret) {
-        const spotifyHTML = await fetch(SPOTIFY_URLS[Math.floor(Math.random() * SPOTIFY_URLS.length)], {
-            headers: {
-                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
-            }
-        })
-            .then(res => {
-                if (!res.ok) throw new Error(`Failed to fetch Spotify page: ${res.statusText}`);
-                return res.text();
-            });
+export async function grabSpotifyAnonToken(cachedSecrets?: SpotifySecret[]): Promise<AnonTokenData> {
+    const spotifyHTML = await fetch(SPOTIFY_URLS[Math.floor(Math.random() * SPOTIFY_URLS.length)], {
+        headers: { "User-Agent": USER_AGENT },
+    }).then((res) => {
+        if (!res.ok) throw new Error(`Failed to fetch Spotify page: ${res.statusText}`);
+        return res.text();
+    });
 
-        const parsed = parse(spotifyHTML);
+    const parsed = parse(spotifyHTML);
 
+    const appConfig = parsed.getElementById("appServerConfig");
+    if (!appConfig) throw new Error("Unable to retrieve app config");
+    const appConfJson = JSON.parse(Buffer.from(appConfig.textContent, "base64").toString()) as { clientVersion: string };
+    const clientVersion = appConfJson.clientVersion;
+
+    let secrets = cachedSecrets;
+
+    if (!secrets) {
         const scriptTags = parsed.querySelectorAll("script");
+        const webPlayer = scriptTags.find((tag) => tag.attributes.src?.includes("web-player."));
+        if (!webPlayer) throw new Error("Unable to extract web player script");
 
-        const webPlayer = scriptTags.find(tag => tag.attributes.src?.includes("web-player."));
-
-        if (!webPlayer) {
-            throw new Error("Unable to extract web player script");
-        }
-
-        const webPlayerUrl = webPlayer.attributes.src;
-        const webPlayerScript = await fetch(webPlayerUrl, {
-            headers: {
-                "User-Agent": USER_AGENT
-            }
-        }).then(res => {
+        const webPlayerScript = await fetch(webPlayer.attributes.src, {
+            headers: { "User-Agent": USER_AGENT },
+        }).then((res) => {
             if (!res.ok) throw new Error(`Failed to fetch web player script: ${res.statusText}`);
             return res.text();
         });
 
-        const arrayWithObjectRegex = /\[(?:[^\[\]]|\[[^\[\]]*\])*\]/gm;
-
-        const allArrays = webPlayerScript.match(arrayWithObjectRegex)?.filter(v => v.includes("secret"))
+        const arrayWithObjectRegex = /\[(?:[^[\]]|\[[^[\]]*\])*\]/gm;
+        const allArrays = webPlayerScript.match(arrayWithObjectRegex)?.filter((v) => v.includes("secret"));
         const secretRaw = allArrays?.[0];
-
         if (!secretRaw) throw new Error("Unable to extract secret");
 
-        secret = jsLiteralToObject(secretRaw).map(v => ({ secret: transformSecret(v.secret), version: v.version }));
+        secrets = jsLiteralToObject(secretRaw).map((v) => ({
+            secret: transformSecret(v.secret),
+            version: v.version,
+        }));
     }
 
     const totp = new TOTP({
         algorithm: "SHA1",
         digits: 6,
         period: 30,
-        secret: Secret.fromHex(secret[0].secret)
+        secret: Secret.fromHex(secrets[0].secret),
     });
 
     const serverTime = Math.floor(Date.now() / 1000);
     const totpClient = totp.generate();
-    const totpServer = totp.generate({
-        timestamp: serverTime
-    });
+    const totpServer = totp.generate({ timestamp: serverTime });
 
-    const url = new URL("https://open.spotify.com/api/token");
-    const searchParams = url.searchParams;
+    const tokenUrl = new URL("https://open.spotify.com/api/token");
+    tokenUrl.searchParams.set("reason", "init");
+    tokenUrl.searchParams.set("productType", "web-player");
+    tokenUrl.searchParams.set("totp", totpClient);
+    tokenUrl.searchParams.set("totpServer", totpServer);
+    tokenUrl.searchParams.set("totpVer", secrets[0].version.toString());
 
-    searchParams.set("reason", "init");
-    searchParams.set("productType", "web-player");
-    searchParams.set("totp", totpClient);
-    searchParams.set("totpServer", totpServer);
-    searchParams.set("totpVer", secret[0].version.toString());
-
-    const tokenResponse = await fetch(url.toString(), {
-        headers: {
-            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
-        }
-    }).then(res => {
+    const tokens = await fetch(tokenUrl.toString(), {
+        headers: { "User-Agent": USER_AGENT },
+    }).then((res) => {
         if (!res.ok) throw new Error(`Failed to fetch Spotify token: ${res.statusText}`);
         return res.json();
-    });
+    }) as AnonymousSpotifyTokenResponse;
+
+    const clientTokenResponse = await fetch("https://clienttoken.spotify.com/v1/clienttoken", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
+            "Origin": "https://open.spotify.com",
+            "Referer": "https://open.spotify.com",
+            "Accept": "application/json",
+        },
+        body: JSON.stringify({
+            client_data: {
+                client_version: clientVersion,
+                client_id: tokens.clientId,
+                js_sdk_data: {
+                    device_brand: "unknown",
+                    device_model: "unknown",
+                    os: "linux",
+                    os_version: "unknown",
+                    device_id: crypto.randomUUID(),
+                    device_type: "computer",
+                },
+            },
+        }),
+    }).then((res) => res.json()) as SPClientTokenResponse;
 
     return {
-        tokens: tokenResponse as AnonymousSpotifyTokenResponse,
-        secrets: secret // cache this for around 6 hours
-    }
+        tokens,
+        clientToken: clientTokenResponse.granted_token.token,
+        clientVersion,
+        secrets, // cache for ~6 hours (re-use on subsequent token refreshes)
+    };
 }

--- a/src/internal/spotify.ts
+++ b/src/internal/spotify.ts
@@ -5,12 +5,12 @@ import { Buffer } from "node:buffer";
 import { grabSpotifyAnonToken, type SpotifySecret } from "./grabSpotifyToken";
 
 const SP_BASE = "https://api.spotify.com/v1";
+const SP_PARTNER_GRAPHQL = "https://api-partner.spotify.com/pathfinder/v2/query";
 
 // Persisted query hashes from Spotify's JS bundle — may need updating if Spotify rotates them
 const GRAPHQL_SEARCH_HASH = "3c9d3f60dac5dea3876b6db3f534192b1c1d90032c4233c1bbaba526db41eb31";
 const GRAPHQL_PLAYLIST_HASH = "346811f856fb0b7e4f6c59f8ebea78dd081c6e2fb01b77c954b26259d5fc6763";
 const GRAPHQL_ALBUM_HASH = "b9bfabef66ed756e5e13f68a942deb60bd4125ec1f1be8cc42769dc0259b4b10";
-const GRAPHQL_LOOKUP_HASH = "5bb408450626d595cb24363104b612e14f9b966430f599121696e8996ea03794";
 
 interface SP_ACCESS_TOKEN {
     token: string;
@@ -254,7 +254,7 @@ export class SpotifyAPI {
                 },
             };
 
-            const res = await this.fetchData("https://api-partner.spotify.com/pathfinder/v2/query", {
+            const res = await this.fetchData(SP_PARTNER_GRAPHQL, {
                 method: "POST",
                 body: JSON.stringify(payload),
                 headers: { "Content-Type": "application/json" },
@@ -288,7 +288,7 @@ export class SpotifyAPI {
                         enableWatchFeedEntrypoint: true,
                     },
                 };
-                const res = await this.fetchData("https://api-partner.spotify.com/pathfinder/v2/query", {
+                const res = await this.fetchData(SP_PARTNER_GRAPHQL, {
                     method: "POST",
                     body: JSON.stringify(payload),
                     headers: { "Content-Type": "application/json" },
@@ -316,7 +316,6 @@ export class SpotifyAPI {
                         },
                     };
                 });
-                console.log("tracks:", tracks.length);
 
                 if (!tracks.length) return null;
 
@@ -414,7 +413,7 @@ export class SpotifyAPI {
                             limit: 50,
                         },
                     };
-                    const res = await this.fetchData("https://api-partner.spotify.com/pathfinder/v2/query", {
+                    const res = await this.fetchData(SP_PARTNER_GRAPHQL, {
                         method: "POST",
                         body: JSON.stringify(payload),
                         headers: { "Content-Type": "application/json" },

--- a/src/internal/spotify.ts
+++ b/src/internal/spotify.ts
@@ -1,15 +1,137 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Secret, TOTP } from "otpauth";
 import { UA, market } from "./helper";
 import { parse } from "node-html-parser";
 import { Buffer } from "node:buffer";
+import { grabSpotifyAnonToken, type SpotifySecret } from "./grabSpotifyToken";
 
 const SP_BASE = "https://api.spotify.com/v1";
 
+// Persisted query hashes from Spotify's JS bundle — may need updating if Spotify rotates them
+const GRAPHQL_SEARCH_HASH = "3c9d3f60dac5dea3876b6db3f534192b1c1d90032c4233c1bbaba526db41eb31";
+const GRAPHQL_PLAYLIST_HASH = "346811f856fb0b7e4f6c59f8ebea78dd081c6e2fb01b77c954b26259d5fc6763";
+const GRAPHQL_ALBUM_HASH = "b9bfabef66ed756e5e13f68a942deb60bd4125ec1f1be8cc42769dc0259b4b10";
+const GRAPHQL_LOOKUP_HASH = "5bb408450626d595cb24363104b612e14f9b966430f599121696e8996ea03794";
+
 interface SP_ACCESS_TOKEN {
-  token: string;
-  expiresAfter: number;
-  type: "Bearer";
+    token: string;
+    expiresAfter: number;
+    type: "Bearer";
+    clientToken?: string;
+    clientVersion?: string;
+}
+
+interface SPTrackMetadata {
+    name: string;
+    artist: { name: string }[];
+    album: {
+        cover_group: {
+            image: { file_id: string; size: string; width: number; height: number }[];
+        };
+    };
+    duration: number;
+}
+
+interface SPGraphQLSearchResponse {
+    data: {
+        searchV2: {
+            tracksV2: {
+                items: Array<{
+                    item: {
+                        data: {
+                            id: string;
+                            name: string;
+                            duration: { totalMilliseconds: number };
+                            artists: { items: Array<{ profile: { name: string } }> };
+                            albumOfTrack: { coverArt: { sources: Array<{ url: string }> } };
+                        };
+                    };
+                }>;
+            };
+        };
+    };
+}
+
+interface SPGraphQLPlaylistResponse {
+    data: {
+        playlistV2: {
+            __typename: string;
+            // metadata — present with fetchPlaylist, absent with fetchPlaylistContents
+            name?: string;
+            ownerV2?: { data: { name: string } };
+            images?: { items: Array<{ sources: Array<{ height: number; url: string; width: number }> }> };
+            content: {
+                __typename: string;
+                items: Array<{
+                    uid: string;
+                    itemV2: {
+                        __typename: string; // "TrackResponseWrapper" for tracks
+                        data: {
+                            __typename: string;
+                            uri: string; // "spotify:track:{id}"
+                            name: string;
+                            trackDuration: { totalMilliseconds: number };
+                            artists: { items: Array<{ profile: { name: string } }> };
+                            albumOfTrack: {
+                                coverArt: {
+                                    sources: Array<{ height: number; url: string; width: number }>;
+                                };
+                            };
+                        };
+                    };
+                }>;
+            };
+        };
+    };
+}
+
+interface SPGraphQLAlbumResponse {
+    data: {
+        albumUnion: {
+            __typename: string;
+            name: string;
+            uri: string;
+            artists: {
+                items: Array<{
+                    id: string;
+                    uri: string;
+                    profile: { name: string };
+                }>;
+            };
+            coverArt: {
+                sources: Array<{ height: number; url: string; width: number }>;
+            };
+            tracksV2: {
+                totalCount: number;
+                items: Array<{
+                    uid: string;
+                    track: {
+                        name: string;
+                        uri: string;
+                        duration: { totalMilliseconds: number };
+                        artists: {
+                            items: Array<{
+                                uri: string;
+                                profile: { name: string };
+                            }>;
+                        };
+                        playability: { playable: boolean };
+                    };
+                }>;
+            };
+        };
+    };
+}
+
+
+function spotifyBase62ToHex(base62Id: string): string {
+    const alphabet = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    let value = 0n;
+    for (const char of base62Id) {
+        const index = BigInt(alphabet.indexOf(char));
+        if (index === -1n) throw new Error(`Invalid character in ID: ${char}`);
+        value = value * 62n + index;
+    }
+    return value.toString(16).padStart(32, "0");
 }
 
 export class SpotifyAPI {
@@ -18,11 +140,11 @@ export class SpotifyAPI {
     private clientSecret: string | undefined;
     private market: string;
     public useCredentials: boolean = false;
+    private _cachedSecrets: SpotifySecret[] | undefined;
 
     constructor(credentials: { clientId?: string; clientSecret?: string; market?: string }) {
         if (credentials.clientId && credentials.clientSecret) {
             this.useCredentials = true;
-
             this.clientId = credentials.clientId;
             this.clientSecret = credentials.clientSecret;
         }
@@ -35,16 +157,8 @@ export class SpotifyAPI {
 
     public async requestToken() {
         try {
-            const accessTokenUrl = await this.getAccessTokenUrl();
-
-            const fetchOptions: RequestInit = !this.useCredentials
-                ? {
-                    headers: {
-                        Referer: "https://open.spotify.com/",
-                        Origin: "https://open.spotify.com",
-                    },
-                }
-                : {
+            if (this.useCredentials) {
+                const tokenData = await fetch("https://accounts.spotify.com/api/token", {
                     method: "POST",
                     headers: {
                         "User-Agent": UA,
@@ -52,31 +166,27 @@ export class SpotifyAPI {
                         "Content-Type": "application/x-www-form-urlencoded",
                     },
                     body: "grant_type=client_credentials",
-                };
+                }).then((v) => v.json());
 
-            const tokenData = await fetch(accessTokenUrl, fetchOptions).then((v) => v.json());
-            if (!tokenData) throw new Error("Failed to retrieve access token.");
-
-            this.accessToken = {
-                token: !this.useCredentials ? tokenData.accessToken : tokenData.access_token,
-                expiresAfter: !this.useCredentials ? tokenData.accessTokenExpirationTimestampMs : Date.now() + tokenData.expires_in * 1000,
-                type: "Bearer",
-            };
-        } catch (error) {
-            try {
-                const response = await fetch("https://open.spotify.com/");
-                const body = await response.text();
-                const token = body.match(/"accessToken":"(.+?)"/)?.[1];
-                const expiresAfter = Number(body.match(/"accessTokenExpirationTimestampMs":(\d+)/)?.[1]) || 1000 * 60 * 60;
-                if (!token) throw new Error("Failed to retrieve access token from Spotify.");
+                if (!tokenData) throw new Error("Failed to retrieve access token.");
                 this.accessToken = {
-                    token,
-                    expiresAfter: expiresAfter,
+                    token: tokenData.access_token,
+                    expiresAfter: Date.now() + tokenData.expires_in * 1000,
                     type: "Bearer",
                 };
-            } catch (error) {
-                throw new Error("Failed to retrieve access token from Spotify.");
+            } else {
+                const anonData = await grabSpotifyAnonToken(this._cachedSecrets);
+                this._cachedSecrets = anonData.secrets;
+                this.accessToken = {
+                    token: anonData.tokens.accessToken,
+                    expiresAfter: anonData.tokens.accessTokenExpirationTimestampMs,
+                    type: "Bearer",
+                    clientToken: anonData.clientToken,
+                    clientVersion: anonData.clientVersion,
+                };
             }
+        } catch {
+            throw new Error("Failed to retrieve access token from Spotify.");
         }
     }
 
@@ -88,31 +198,74 @@ export class SpotifyAPI {
         if (this.isTokenExpired()) await this.requestToken();
     }
 
-    private async fetchData(apiUrl: string) {
+    private async fetchData(apiUrl: string, options?: RequestInit) {
         await this.ensureValidToken();
+        const headers: Record<string, string> = {
+            Authorization: `Bearer ${this.accessToken?.token}`,
+            Referer: "https://open.spotify.com/",
+            Origin: "https://open.spotify.com",
+            "User-Agent": UA,
+            Accept: "application/json",
+        };
+        if (!this.useCredentials && this.accessToken?.clientToken) {
+            headers["client-token"] = this.accessToken.clientToken;
+            headers["spotify-app-version"] = this.accessToken.clientVersion || "";
+            headers["app-platform"] = "WebPlayer";
+        }
         const res = await fetch(apiUrl, {
-            headers: {
-                Authorization: `Bearer ${this.accessToken?.token}`,
-                Referer: "https://open.spotify.com/",
-                Origin: "https://open.spotify.com",
-            },
+            ...options,
+            headers: { ...headers, ...(options?.headers as Record<string, string> ?? {}) },
         });
-
-        if (!res.ok) throw new Error("Failed to fetch Spotify data.");
+        if (!res.ok) throw new Error(`Failed to fetch Spotify data: ${res.status}`);
         return res;
     }
 
     public async search(query: string) {
         try {
-            const res = await this.fetchData(`${SP_BASE}/search/?q=${encodeURIComponent(query)}&type=track${this.market ? `&market=${this.market}` : ""}`);
-            const data: { tracks: { items: SpotifyTrack[] } } = await res.json();
+            if (this.useCredentials) {
+                const res = await this.fetchData(
+                    `${SP_BASE}/search/?q=${encodeURIComponent(query)}&type=track${this.market ? `&market=${this.market}` : ""}`,
+                );
+                const data: { tracks: { items: SpotifyTrack[] } } = await res.json();
+                return data.tracks.items.map((m) => ({
+                    title: m.name,
+                    duration: m.duration_ms,
+                    artist: m.artists.map((artist) => artist.name).join(", "),
+                    url: m.external_urls?.spotify || `https://open.spotify.com/track/${m.id}`,
+                    thumbnail: m.album.images?.[0]?.url || null,
+                }));
+            }
 
-            return data.tracks.items.map((m) => ({
-                title: m.name,
-                duration: m.duration_ms,
-                artist: m.artists.map((artist) => artist.name).join(", "),
-                url: m.external_urls?.spotify || `https://open.spotify.com/track/${m.id}`,
-                thumbnail: m.album.images?.[0]?.url || null,
+            // Anon: use partner GraphQL API
+            const payload = {
+                extensions: {
+                    persistedQuery: { sha256Hash: GRAPHQL_SEARCH_HASH, version: 1 },
+                },
+                operationName: "searchDesktop",
+                variables: {
+                    searchTerm: query,
+                    includeArtistHasConcertsField: false,
+                    includeAudiobooks: false,
+                    includeAuthors: false,
+                    includePreReleases: false,
+                    limit: 10,
+                    numberOfTopResults: 5,
+                    offset: 0,
+                },
+            };
+
+            const res = await this.fetchData("https://api-partner.spotify.com/pathfinder/v2/query", {
+                method: "POST",
+                body: JSON.stringify(payload),
+                headers: { "Content-Type": "application/json" },
+            });
+            const data: SPGraphQLSearchResponse = await res.json();
+            return data.data.searchV2.tracksV2.items.map((item) => ({
+                title: item.item.data.name,
+                duration: item.item.data.duration.totalMilliseconds,
+                artist: item.item.data.artists.items.map((a) => a.profile.name).join(", "),
+                url: `https://open.spotify.com/track/${item.item.data.id}`,
+                thumbnail: item.item.data.albumOfTrack?.coverArt?.sources?.[0]?.url || null,
             }));
         } catch {
             return null;
@@ -120,26 +273,90 @@ export class SpotifyAPI {
     }
 
     public async getPlaylist(id: string) {
+        if (!this.useCredentials) {
+            // Anon: use partner GraphQL API - max limit is 5000 (default is 50)
+            try {
+                const payload = {
+                    extensions: {
+                        persistedQuery: { sha256Hash: GRAPHQL_PLAYLIST_HASH, version: 1 },
+                    },
+                    operationName: "fetchPlaylist",
+                    variables: {
+                        uri: `spotify:playlist:${id}`,
+                        offset: 0,
+                        limit: 5000,
+                        enableWatchFeedEntrypoint: true,
+                    },
+                };
+                const res = await this.fetchData("https://api-partner.spotify.com/pathfinder/v2/query", {
+                    method: "POST",
+                    body: JSON.stringify(payload),
+                    headers: { "Content-Type": "application/json" },
+                });
+                const data: SPGraphQLPlaylistResponse = await res.json();
+                const playlistData = data.data.playlistV2;
+
+                const trackItems = playlistData.content.items.filter(
+                    (item) => item.itemV2?.__typename === "TrackResponseWrapper" && item.itemV2.data.__typename !== "NotFound",
+                );
+
+                const tracks = trackItems.map((item) => {
+                    const track = item.itemV2.data;
+                    const trackId = track.uri.split(":").pop() || "";
+                    return {
+                        name: track.name,
+                        duration_ms: track.trackDuration.totalMilliseconds,
+                        artists: track.artists.items.map((a) => ({ id: "", name: a.profile.name })),
+                        external_urls: { spotify: `https://open.spotify.com/track/${trackId}` },
+                        id: trackId,
+                        album: {
+                            images: (track.albumOfTrack?.coverArt?.sources ?? [])
+                                .sort((a, b) => (b.height || 0) - (a.height || 0))
+                                .map((s) => ({ url: s.url, height: s.height || 0, width: s.width || 0 })),
+                        },
+                    };
+                });
+                console.log("tracks:", tracks.length);
+
+                if (!tracks.length) return null;
+
+                const playlistThumbnail =
+                    playlistData.images?.items?.[0]?.sources?.sort((a, b) => (b.height || 0) - (a.height || 0))?.[0]?.url ||
+                    trackItems[0]?.itemV2.data.albumOfTrack?.coverArt?.sources?.sort((a, b) => (b.height || 0) - (a.height || 0))?.[0]?.url ||
+                    null;
+
+                return {
+                    name: playlistData.name ?? "",
+                    author: playlistData.ownerV2?.data?.name || "",
+                    thumbnail: playlistThumbnail,
+                    id,
+                    url: `https://open.spotify.com/playlist/${id}`,
+                    tracks,
+                };
+            } catch {
+                return null;
+            }
+        }
+
         try {
             const res = await this.fetchData(`${SP_BASE}/playlists/${id}${this.market ? `?market=${this.market}` : ""}`);
             if (!res) return null;
 
             const data: {
-        external_urls: { spotify: string };
-        owner: { display_name: string };
-        id: string;
-        name: string;
-        images: { url: string }[];
-        tracks: {
-          items: { track: SpotifyTrack }[];
-          next?: string;
-        };
-      } = await res.json();
+                external_urls: { spotify: string };
+                owner: { display_name: string };
+                id: string;
+                name: string;
+                images: { url: string }[];
+                tracks: {
+                    items: { track: SpotifyTrack }[];
+                    next?: string;
+                };
+            } = await res.json();
 
             if (!data.tracks.items.length) return null;
 
             const t: { track: SpotifyTrack }[] = data.tracks.items;
-
             let next: string | undefined = data.tracks.next;
 
             while (typeof next === "string") {
@@ -147,10 +364,8 @@ export class SpotifyAPI {
                     const nextRes = await this.fetchData(next);
                     if (!nextRes) break;
                     const nextPage: { items: { track: SpotifyTrack }[]; next?: string } = await nextRes.json();
-
                     t.push(...nextPage.items);
                     next = nextPage.next;
-
                     if (!next) break;
                 } catch {
                     break;
@@ -165,9 +380,7 @@ export class SpotifyAPI {
                     artists: m.artists,
                     external_urls: m.external_urls,
                     id: m.id,
-                    album: {
-                        images: m.album.images,
-                    },
+                    album: { images: m.album.images },
                 }));
 
             if (!tracks.length) return null;
@@ -179,34 +392,104 @@ export class SpotifyAPI {
                 url: data.external_urls.spotify || `https://open.spotify.com/playlist/${id}`,
                 tracks,
             };
-        } catch (err) {
+        } catch {
             return null;
         }
     }
 
     public async getAlbum(id: string) {
-        // if (!this.clientId || !this.clientSecret) throw new Error("Spotify clientId and clientSecret are required.");
+        if (!this.useCredentials) {
+            // Anon: use partner GraphQL API
+            try {
+                const fetchPage = async (offset: number): Promise<SPGraphQLAlbumResponse> => {
+                    const payload = {
+                        extensions: {
+                            persistedQuery: { sha256Hash: GRAPHQL_ALBUM_HASH, version: 1 },
+                        },
+                        operationName: "getAlbum",
+                        variables: {
+                            uri: `spotify:album:${id}`,
+                            locale: "",
+                            offset,
+                            limit: 50,
+                        },
+                    };
+                    const res = await this.fetchData("https://api-partner.spotify.com/pathfinder/v2/query", {
+                        method: "POST",
+                        body: JSON.stringify(payload),
+                        headers: { "Content-Type": "application/json" },
+                    });
+                    return res.json();
+                };
+
+                const firstPage = await fetchPage(0);
+                const albumData = firstPage.data.albumUnion;
+                const allItems = [...albumData.tracksV2.items];
+                const totalCount = albumData.tracksV2.totalCount;
+
+                while (allItems.length < totalCount) {
+                    try {
+                        const nextPage = await fetchPage(allItems.length);
+                        const newItems = nextPage.data.albumUnion.tracksV2.items;
+                        if (!newItems.length) break;
+                        allItems.push(...newItems);
+                    } catch {
+                        break;
+                    }
+                }
+
+                const albumImages = albumData.coverArt.sources
+                    .sort((a, b) => (b.height || 0) - (a.height || 0))
+                    .map((s) => ({ url: s.url, height: s.height || 0, width: s.width || 0 }));
+
+                const tracks = allItems
+                    .filter((item) => item.track?.name)
+                    .map((item) => {
+                        const track = item.track;
+                        const trackId = track.uri.split(":").pop() || "";
+                        return {
+                            name: track.name,
+                            duration_ms: track.duration.totalMilliseconds,
+                            artists: track.artists.items.map((a) => ({ id: "", name: a.profile.name })),
+                            external_urls: { spotify: `https://open.spotify.com/track/${trackId}` },
+                            id: trackId,
+                            album: { images: albumImages },
+                        };
+                    });
+
+                if (!tracks.length) return null;
+                return {
+                    name: albumData.name,
+                    author: albumData.artists.items.map((a) => a.profile.name).join(", "),
+                    thumbnail: albumImages[0]?.url || null,
+                    id,
+                    url: `https://open.spotify.com/album/${id}`,
+                    tracks,
+                };
+            } catch {
+                return null;
+            }
+        }
 
         try {
             const res = await this.fetchData(`${SP_BASE}/albums/${id}${this.market ? `?market=${this.market}` : ""}`);
             if (!res) return null;
 
             const data: {
-        external_urls: { spotify: string };
-        artists: { name: string }[];
-        id: string;
-        name: string;
-        images: { url: string }[];
-        tracks: {
-          items: SpotifyTrack[];
-          next?: string;
-        };
-      } = await res.json();
+                external_urls: { spotify: string };
+                artists: { name: string }[];
+                id: string;
+                name: string;
+                images: { url: string }[];
+                tracks: {
+                    items: SpotifyTrack[];
+                    next?: string;
+                };
+            } = await res.json();
 
             if (!data.tracks.items.length) return null;
 
             const t: SpotifyTrack[] = data.tracks.items;
-
             let next: string | undefined = data.tracks.next;
 
             while (typeof next === "string") {
@@ -214,10 +497,8 @@ export class SpotifyAPI {
                     const nextRes = await this.fetchData(next);
                     if (!nextRes) break;
                     const nextPage: { items: SpotifyTrack[]; next?: string } = await nextRes.json();
-
                     t.push(...nextPage.items);
                     next = nextPage.next;
-
                     if (!next) break;
                 } catch {
                     break;
@@ -232,9 +513,7 @@ export class SpotifyAPI {
                     artists: m.artists,
                     external_urls: m.external_urls,
                     id: m.id,
-                    album: {
-                        images: data.images || [],
-                    },
+                    album: { images: data.images || [] },
                 }));
 
             if (!tracks.length) return null;
@@ -253,18 +532,39 @@ export class SpotifyAPI {
 
     public async getTrack(id: string) {
         try {
-            const res = await this.fetchData(`${SP_BASE}/tracks/${id}${this.market ? `?market=${this.market}` : ""}`);
-            if (!res) return null;
+            if (this.useCredentials) {
+                const res = await this.fetchData(`${SP_BASE}/tracks/${id}${this.market ? `?market=${this.market}` : ""}`);
+                if (!res) return null;
+                const track: SpotifyTrack = await res.json();
+                return {
+                    name: track.name,
+                    duration_ms: track.duration_ms,
+                    artists: track.artists,
+                    external_urls: track.external_urls,
+                    id: track.id,
+                    album: { images: track.album.images },
+                };
+            }
 
-            const track: SpotifyTrack = await res.json();
+            // Anon: use private SP Client API
+            const hexId = spotifyBase62ToHex(id);
+            const res = await this.fetchData(`https://spclient.wg.spotify.com/metadata/4/track/${hexId}?market=from_token`);
+            const metadata: SPTrackMetadata = await res.json();
+
             return {
-                name: track.name,
-                duration_ms: track.duration_ms,
-                artists: track.artists,
-                external_urls: track.external_urls,
-                id: track.id,
+                name: metadata.name,
+                duration_ms: metadata.duration,
+                artists: (metadata.artist ?? []).map((a) => ({ id: "", name: a.name })),
+                external_urls: { spotify: `https://open.spotify.com/track/${id}` },
+                id,
                 album: {
-                    images: track.album.images,
+                    images: (metadata.album?.cover_group?.image ?? [])
+                        .sort((a, b) => (b.width || 0) - (a.width || 0))
+                        .map((img) => ({
+                            url: `https://i.scdn.co/image/${img.file_id}`,
+                            height: img.height || 0,
+                            width: img.width || 0,
+                        })),
                 },
             };
         } catch {
@@ -272,26 +572,10 @@ export class SpotifyAPI {
         }
     }
 
-    public async getRecommendations(trackIds: Array<string>, limit?: number) {
-        try {
-            if (this.useCredentials) throw new Error("getRecommendations endpoint is not supported when using credentials.");
-
-            const res = await this.fetchData(
-                `${SP_BASE}/recommendations/?seed_tracks=${trackIds.join(",")}&limit=${limit || "100"}${this.market ? `&market=${this.market}` : ""}`,
-            );
-            if (!res) return null;
-            const data: { tracks: SpotifyTrack[] } = await res.json();
-
-            return data.tracks.map((m) => ({
-                title: m.name,
-                duration: m.duration_ms,
-                artist: m.artists.map((artist) => artist.name).join(", "),
-                url: m.external_urls?.spotify || `https://open.spotify.com/track/${m.id}`,
-                thumbnail: m.album.images?.[0]?.url || null,
-            }));
-        } catch {
-            return null;
-        }
+    public async getRecommendations(trackIds: string[]) {
+        // Credentials: unsupported via SP Public API - could add option to use private SPclient API separately
+        // TODO: implement a way to fetch recommendations using anonymous token
+        return [];
     }
 
     /**
@@ -311,8 +595,6 @@ export class SpotifyAPI {
         type: "track" | "playlist" | "album" = "track",
     ): Promise<any | null> {
         const embedUrl = SpotifyAPI.getEmbedLink(url, type);
-        // Optionally remove or replace console.log in production
-        // console.log(embedUrl);
         const html = await fetch(embedUrl).then(r => r.text());
         const root = parse(html);
         let jsonData: any;
@@ -324,8 +606,6 @@ export class SpotifyAPI {
             jsonData = JSON.parse(scriptTag.text);
         else
             return null;
-        // Optionally remove or replace console.log in production
-        // console.log(jsonData);
 
         switch (type) {
             case "track": {
@@ -371,106 +651,23 @@ export class SpotifyAPI {
             default: return null;
         }
     }
-
-    private buildTokenUrl() {
-        const baseUrl = new URL("https://open.spotify.com/api/token");
-        baseUrl.searchParams.set("reason", "init");
-        baseUrl.searchParams.set("productType", "web-player");
-        return baseUrl;
-    }
-
-    private calculateToken(hex: Array<number>) {
-        const token = hex.map((v, i) => v ^ ((i % 33) + 9));
-        const bufferToken = Buffer.from(token.join(""), "utf8").toString("hex");
-        return Secret.fromHex(bufferToken);
-    }
-
-    private async getAccessTokenUrl() {
-        if (this.useCredentials) return "https://accounts.spotify.com/api/token?grant_type=client_credentials";
-
-        const token = this.calculateToken([12, 56, 76, 33, 88, 44, 88, 33, 78, 78, 11, 66, 22, 22, 55, 69, 54]);
-
-        const spotifyHtml = await fetch("https://open.spotify.com", {
-            headers: {
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
-            },
-        }).then((v) => v.text());
-        const root = parse(spotifyHtml);
-        const scriptTags = root.querySelectorAll("script");
-        const playerSrc = scriptTags.find((v) => v.getAttribute("src")?.includes("web-player/web-player."))?.getAttribute("src");
-        if (!playerSrc) throw new Error("Could not find player script source");
-        const playerScript = await fetch(playerSrc, {
-            headers: {
-                Dnt: "1",
-                Referer: "https://open.spotify.com/",
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
-            },
-        }).then((v) => v.text());
-
-        const versionMatch = playerScript.match(/buildVer["']?\s*:\s*["']?([^,"'}\s]+)["']?,\s*buildDate["']?\s*:\s*["']?([^,"'}\s]+)["']?/);
-        if (!versionMatch) 
-            throw new Error("Could not extract buildVer/buildDate from player script");
-    
-        const version = {
-            buildVer: versionMatch[1],
-            buildDate: versionMatch[2],
-        };
-
-        const url = this.buildTokenUrl();
-        const { searchParams } = url;
-
-        const cTime = Date.now();
-        const sTime = await fetch("https://open.spotify.com/api/server-time/", {
-            headers: {
-                Referer: "https://open.spotify.com/",
-                Origin: "https://open.spotify.com",
-                "User-Agent": UA,
-            },
-        })
-            .then((v) => v.json())
-            .then((v) => v.serverTime);
-
-        const totp = new TOTP({
-            secret: token,
-            period: 30,
-            digits: 6,
-            algorithm: "SHA1",
-        });
-
-        const totpServer = totp.generate({
-            timestamp: sTime * 1e3,
-        });
-        const totpClient = totp.generate({
-            timestamp: cTime,
-        });
-
-        searchParams.set("sTime", String(sTime));
-        searchParams.set("cTime", String(cTime));
-        searchParams.set("totp", totpClient);
-        searchParams.set("totpServer", totpServer);
-        searchParams.set("totpVer", "5");
-        searchParams.set("buildVer", version.buildVer);
-        searchParams.set("buildDate", version.buildDate);
-
-        return url;
-    }
 }
 
 export interface SpotifyTrack {
-  album: {
-    images: {
-      height: number;
-      url: string;
-      width: number;
+    album: {
+        images: {
+            height: number;
+            url: string;
+            width: number;
+        }[];
+    };
+    artists: {
+        id: string;
+        name: string;
     }[];
-  };
-  artists: {
+    duration_ms: number;
+    explicit: boolean;
+    external_urls: { spotify: string };
     id: string;
     name: string;
-  }[];
-  duration_ms: number;
-  explicit: boolean;
-  external_urls: { spotify: string };
-  id: string;
-  name: string;
 }


### PR DESCRIPTION
Replaced the broken anonymous token implementation with a TOTP-based approach and switches all anon API calls from the public Spotify API to private partner/spclient endpoints that accept anonymous tokens. Added support for anon track lookup, search, playlist and album.

Public API endpoints need to be updated due to the recent breaking changes to the API.