### PR TITLE
fix: update for Feb 2026 API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ await player.extractors.register(SpotifyExtractor, { /* options */ });
 | Can bridge to ... | ✅ |
 | Autoplay | ✅* |
 
-\* Autoplay works differently whether you use credentials or not.
+\* Autoplay is a work in progress. Currently, it simply fetches a track from the same artist.
 
 ## Options
 
@@ -44,6 +44,7 @@ await player.extractors.register(SpotifyExtractor, { /* options */ });
 | clientSecret | string | null | No | Your Spotify client secret |
 | market | string | "" | No | The market to use for the Spotify API. |
 | createStream(ext: SpotifyExtractor, url: string) => Promise<Readable \| string>; | function | null | No | A function that returns a Readable stream or a string URL to the stream. |
+| playlistFetchLimitAnon | number | 25 | No | Limits the number of tracks fetched from a playlist when using anon mode. |
 
 [Information on the market parameter and the reason why it is required.](https://developer.spotify.com/documentation/web-api/concepts/track-relinking)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ await player.extractors.register(SpotifyExtractor, { /* options */ });
 | clientSecret | string | null | No | Your Spotify client secret |
 | market | string | "" | No | The market to use for the Spotify API. |
 | createStream(ext: SpotifyExtractor, url: string) => Promise<Readable \| string>; | function | null | No | A function that returns a Readable stream or a string URL to the stream. |
-| playlistFetchLimitAnon | number | 25 | No | Limits the number of tracks fetched from a playlist when using anon mode. |
+| anon.maxPagingQueries | number | 25 | No | Limits the number of tracks per request fetched for playlists when using anon mode. Must be between 1 and 5000. |
 
 [Information on the market parameter and the reason why it is required.](https://developer.spotify.com/documentation/web-api/concepts/track-relinking)
 

--- a/src/SpotifyExtractor.ts
+++ b/src/SpotifyExtractor.ts
@@ -13,6 +13,11 @@ export interface SpotifyExtractorInit {
   clientSecret?: string;
   market?: string | null;
   createStream?: (ext: SpotifyExtractor, url: string) => Promise<Readable | string>;
+  /**
+   * Number of tracks fetched per page when loading a playlist via the private API.
+   * Must be between 1 and 5000. Defaults to 25.
+   */
+  playlistFetchLimitAnon?: number;
 }
 
 export { parseSpotifyUrl, grabSpotifyAnonToken, type AnonTokenData };
@@ -27,10 +32,16 @@ export class SpotifyExtractor extends BaseExtractor<SpotifyExtractorInit> {
 
     private _market = this.options.market || market;
 
-    public internal = new SpotifyAPI({ ...this._credentials, market: this._market });
+    private _playlistFetchLimitAnon = Math.min(5000, Math.max(1, this.options.playlistFetchLimitAnon ?? 25));
+
+    public internal = new SpotifyAPI({ ...this._credentials, market: this._market, playlistFetchLimitAnon: this._playlistFetchLimitAnon });
 
     public async activate(): Promise<void> {
         this.protocols = ["spsearch", "spotify"];
+
+        const limit = this.options.playlistFetchLimitAnon;
+        if (limit !== undefined && (typeof limit !== "number" || !Number.isInteger(limit) || limit < 1 || limit > 5000))
+            throw new RangeError(`SpotifyExtractor: playlistFetchLimitAnon must be an integer between 1 and 5000 (got ${limit})`);
 
         const fn = this.options.createStream;
         if (typeof fn === "function") {

--- a/src/SpotifyExtractor.ts
+++ b/src/SpotifyExtractor.ts
@@ -14,10 +14,15 @@ export interface SpotifyExtractorInit {
   market?: string | null;
   createStream?: (ext: SpotifyExtractor, url: string) => Promise<Readable | string>;
   /**
-   * Number of tracks fetched per page when loading a playlist via the private API.
-   * Must be between 1 and 5000. Defaults to 25.
+   * Options that apply when running in anon mode.
    */
-  playlistFetchLimitAnon?: number;
+  anon?: {
+    /**
+     * Maximum number of paging requests when fetching a playlist.
+     * Must be between 1 and 5000. Defaults to 25 (web client behavior).
+     */
+    maxPagingQueries?: number;
+  };
 }
 
 export { parseSpotifyUrl, grabSpotifyAnonToken, type AnonTokenData };
@@ -32,16 +37,16 @@ export class SpotifyExtractor extends BaseExtractor<SpotifyExtractorInit> {
 
     private _market = this.options.market || market;
 
-    private _playlistFetchLimitAnon = Math.min(5000, Math.max(1, this.options.playlistFetchLimitAnon ?? 25));
+    private _anonMaxPagingQueries = Math.min(5000, Math.max(1, this.options.anon?.maxPagingQueries ?? 25));
 
-    public internal = new SpotifyAPI({ ...this._credentials, market: this._market, playlistFetchLimitAnon: this._playlistFetchLimitAnon });
+    public internal = new SpotifyAPI({ ...this._credentials, market: this._market, maxPagingQueries: this._anonMaxPagingQueries });
 
     public async activate(): Promise<void> {
         this.protocols = ["spsearch", "spotify"];
 
-        const limit = this.options.playlistFetchLimitAnon;
+        const limit = this.options.anon?.maxPagingQueries;
         if (limit !== undefined && (typeof limit !== "number" || !Number.isInteger(limit) || limit < 1 || limit > 5000))
-            throw new RangeError(`SpotifyExtractor: playlistFetchLimitAnon must be an integer between 1 and 5000 (got ${limit})`);
+            throw new RangeError(`SpotifyExtractor: anon.maxPagingQueries must be an integer between 1 and 5000 (got ${limit})`);
 
         const fn = this.options.createStream;
         if (typeof fn === "function") {

--- a/src/internal/spotify.ts
+++ b/src/internal/spotify.ts
@@ -143,16 +143,16 @@ export class SpotifyAPI {
     public useCredentials: boolean = false;
     private _cachedSecrets: SpotifySecret[] | undefined;
 
-    private playlistFetchLimitAnon: number;
+    private maxPagingQueries: number;
 
-    constructor(credentials: { clientId?: string; clientSecret?: string; market?: string; playlistFetchLimitAnon?: number }) {
+    constructor(credentials: { clientId?: string; clientSecret?: string; market?: string; maxPagingQueries?: number }) {
         if (credentials.clientId && credentials.clientSecret) {
             this.useCredentials = true;
             this.clientId = credentials.clientId;
             this.clientSecret = credentials.clientSecret;
         }
         this.market = credentials.market || market;
-        this.playlistFetchLimitAnon = credentials.playlistFetchLimitAnon ?? 25;
+        this.maxPagingQueries = credentials.maxPagingQueries ?? 25;
     }
 
     private get authorizationKey() {
@@ -261,7 +261,7 @@ export class SpotifyAPI {
         try {
             if (this.useCredentials) {
                 const res = await this.fetchData(
-                    `${SP_BASE}/search/?q=${encodeURIComponent(query)}&type=track${this.market ? `&market=${this.market}` : ""}`,
+                    `${SP_BASE}/search/?q=${encodeURIComponent(query)}&type=track&limit=10${this.market ? `&market=${this.market}` : ""}`,
                 );
                 const data: { tracks: { items: SpotifyTrack[] } } = await res.json();
                 return data.tracks.items.map((m) => ({
@@ -312,7 +312,7 @@ export class SpotifyAPI {
     public async getPlaylist(id: string) {
         if (!this.useCredentials) {
             try {
-                const limit = this.playlistFetchLimitAnon;
+                const limit = this.maxPagingQueries;
                 let offset = 0;
 
                 const allTracks: any[] = [];
@@ -427,22 +427,22 @@ export class SpotifyAPI {
                 id: string;
                 name: string;
                 images: { url: string }[];
-                tracks: {
-                    items: { track: SpotifyTrack }[];
+                items: {
+                    items: { item: SpotifyTrack }[];
                     next?: string;
                 };
             } = await res.json();
 
-            if (!data.tracks.items.length) return null;
+            if (!data.items.items.length) return null;
 
-            const t: { track: SpotifyTrack }[] = data.tracks.items;
-            let next: string | undefined = data.tracks.next;
+            const t: { item: SpotifyTrack }[] = data.items.items;
+            let next: string | undefined = data.items.next;
 
             while (typeof next === "string") {
                 try {
                     const nextRes = await this.fetchData(next);
                     if (!nextRes) break;
-                    const nextPage: { items: { track: SpotifyTrack }[]; next?: string } = await nextRes.json();
+                    const nextPage: { items: { item: SpotifyTrack }[]; next?: string } = await nextRes.json();
                     t.push(...nextPage.items);
                     next = nextPage.next;
                     if (!next) break;
@@ -452,8 +452,8 @@ export class SpotifyAPI {
             }
 
             const tracks = t
-                .filter(({ track: m }) => m?.name && m?.artists)
-                .map(({ track: m }) => ({
+                .filter(({ item: m }) => m?.name && m?.artists)
+                .map(({ item: m }) => ({
                     name: m.name,
                     duration_ms: m.duration_ms,
                     artists: m.artists,
@@ -560,16 +560,16 @@ export class SpotifyAPI {
                 id: string;
                 name: string;
                 images: { url: string }[];
-                tracks: {
+                items: {
                     items: SpotifyTrack[];
                     next?: string;
                 };
             } = await res.json();
 
-            if (!data.tracks.items.length) return null;
+            if (!data.items.items.length) return null;
 
-            const t: SpotifyTrack[] = data.tracks.items;
-            let next: string | undefined = data.tracks.next;
+            const t: SpotifyTrack[] = data.items.items;
+            let next: string | undefined = data.items.next;
 
             while (typeof next === "string") {
                 try {

--- a/src/internal/spotify.ts
+++ b/src/internal/spotify.ts
@@ -143,13 +143,16 @@ export class SpotifyAPI {
     public useCredentials: boolean = false;
     private _cachedSecrets: SpotifySecret[] | undefined;
 
-    constructor(credentials: { clientId?: string; clientSecret?: string; market?: string }) {
+    private playlistFetchLimitAnon: number;
+
+    constructor(credentials: { clientId?: string; clientSecret?: string; market?: string; playlistFetchLimitAnon?: number }) {
         if (credentials.clientId && credentials.clientSecret) {
             this.useCredentials = true;
             this.clientId = credentials.clientId;
             this.clientSecret = credentials.clientSecret;
         }
         this.market = credentials.market || market;
+        this.playlistFetchLimitAnon = credentials.playlistFetchLimitAnon ?? 25;
     }
 
     private get authorizationKey() {
@@ -309,7 +312,7 @@ export class SpotifyAPI {
     public async getPlaylist(id: string) {
         if (!this.useCredentials) {
             try {
-                const limit = 50; // matches Spotify web client behavior
+                const limit = this.playlistFetchLimitAnon;
                 let offset = 0;
 
                 const allTracks: any[] = [];
@@ -317,7 +320,7 @@ export class SpotifyAPI {
                 let total: number | null = null;
 
                 // hard cap just in case (prevents infinite loops if API changes)
-                const MAX_PAGES = 200; // 50 * 200 = 10k tracks max
+                const MAX_PAGES = Math.ceil(10000 / limit);
 
                 for (let page = 0; page < MAX_PAGES; page++) {
                     const payload = {


### PR DESCRIPTION
Breaking changes from the Spotify Web API February 2026 update:
- Playlist response: tracks -> items, track item wrapper -> item
- Album response: tracks -> items
- Search: add explicit limit=10 (API default dropped from 20 to 5, max from 50 to 10)

Adds a configurable maxPagingQueries option that controls how many tracks are fetched per request via the private API (anon mode). Defaults to 25 to match Spotify web client behaviour. Validates that the value is an integer between 1 and 5000.